### PR TITLE
Only play sound if MuPiBox actually shuts down

### DIFF
--- a/scripts/OnOffShim/off_trigger.sh
+++ b/scripts/OnOffShim/off_trigger.sh
@@ -30,9 +30,13 @@ until [ $power = $switchtype ]; do
 	if [ $power = $switchtype ]; then
 		sleep ${PRESS_DELAY}
 		power=$(cat /sys/class/gpio/gpio${TRIGGER_PIN}/value)
-		/usr/bin/pactl set-sink-volume @DEFAULT_SINK@ ${START_VOLUME}% 
-		/usr/bin/aplay /home/dietpi/MuPiBox/sysmedia/sound/button_shutdown.wav
-		#/usr/bin/mplayer -volume ${START_VOLUME} ${START_SOUND} &
+		if [ $power = $switchtype ]; then
+			# only play sound if MuPiBox actually shuts down
+			# Could also go after until loop?
+			/usr/bin/pactl set-sink-volume @DEFAULT_SINK@ ${START_VOLUME}%
+			/usr/bin/aplay /home/dietpi/MuPiBox/sysmedia/sound/button_shutdown.wav
+			#/usr/bin/mplayer -volume ${START_VOLUME} ${START_SOUND} &
+		fi
 	fi
 	sleep 0.05
 done

--- a/scripts/OnOffShim/off_trigger.sh
+++ b/scripts/OnOffShim/off_trigger.sh
@@ -26,7 +26,7 @@ power=$(cat /sys/class/gpio/gpio${TRIGGER_PIN}/value)
 [ $power = 1 ] && switchtype="0" #Momentary button
 
 until [ $power = $switchtype ]; do
-    power=$(cat /sys/class/gpio/gpio${TRIGGER_PIN}/value)
+	power=$(cat /sys/class/gpio/gpio${TRIGGER_PIN}/value)
 	if [ $power = $switchtype ]; then
 		sleep ${PRESS_DELAY}
 		power=$(cat /sys/class/gpio/gpio${TRIGGER_PIN}/value)
@@ -34,7 +34,7 @@ until [ $power = $switchtype ]; do
 		/usr/bin/aplay /home/dietpi/MuPiBox/sysmedia/sound/button_shutdown.wav
 		#/usr/bin/mplayer -volume ${START_VOLUME} ${START_SOUND} &
 	fi
-    sleep 0.05
+	sleep 0.05
 done
 
 sudo service mupi_startstop stop


### PR DESCRIPTION
After waiting for PRESS_DELAY seconds the GPIO state is checked again and the button_shutdown.wav file would play regardless of the GPIO state at that time.
With this patch, the sound only plays when the GPIO is still in pressed state and the MuPiBox would actually shut down.