### PR TITLE
Fix frontend tests

### DIFF
--- a/dev/Sonos-Kids-Controller-master/src/app/add/add.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/add/add.page.spec.ts
@@ -1,25 +1,32 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { AddPage } from './add.page';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing"
 
 describe('AddPage', () => {
   let component: AddPage;
   let fixture: ComponentFixture<AddPage>;
+  let httpClient: HttpTestingController;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ AddPage ],
-      imports: [IonicModule.forRoot(), HttpClientModule]
+      imports: [IonicModule.forRoot(), HttpClientModule, RouterTestingModule, FormsModule, HttpClientTestingModule]
     }).compileComponents();
+
+    httpClient = TestBed.inject(HttpTestingController)
 
     fixture = TestBed.createComponent(AddPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/add/add.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/add/add.page.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { AddPage } from './add.page';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('AddPage', () => {
   let component: AddPage;
@@ -10,7 +11,7 @@ describe('AddPage', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AddPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), HttpClientModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AddPage);

--- a/dev/Sonos-Kids-Controller-master/src/app/add/add.page.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/add/add.page.ts
@@ -58,7 +58,7 @@ export class AddPage implements OnInit, AfterViewInit {
   ) {
     this.validate$ = this.mediaService.validate$;
     this.route.queryParams.subscribe(params => {
-      if (this.router.getCurrentNavigation().extras.state) {
+      if (this.router.getCurrentNavigation()?.extras.state) {
         this.editMedia = this.router.getCurrentNavigation().extras.state.media;
         this.edit = true;
       }

--- a/dev/Sonos-Kids-Controller-master/src/app/admin/admin.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/admin/admin.page.spec.ts
@@ -3,18 +3,23 @@ import { IonicModule } from '@ionic/angular';
 
 import { AdminPage } from './admin.page';
 import { HttpClientModule } from '@angular/common/http';
-import { RouterModule, UrlSerializer } from '@angular/router';
+import { UrlSerializer } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing"
 
 describe('AdminPage', () => {
   let component: AdminPage;
   let fixture: ComponentFixture<AdminPage>;
+  let httpClient: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AdminPage ],
-      imports: [IonicModule.forRoot(), HttpClientModule],
+      imports: [IonicModule.forRoot(), HttpClientModule, FormsModule, HttpClientTestingModule],
       providers: [UrlSerializer]
     }).compileComponents();
+
+    httpClient = TestBed.inject(HttpTestingController)
 
     fixture = TestBed.createComponent(AdminPage);
     component = fixture.componentInstance;
@@ -22,6 +27,7 @@ describe('AdminPage', () => {
   }));
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/admin/admin.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/admin/admin.page.spec.ts
@@ -2,6 +2,8 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { AdminPage } from './admin.page';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterModule, UrlSerializer } from '@angular/router';
 
 describe('AdminPage', () => {
   let component: AdminPage;
@@ -10,7 +12,8 @@ describe('AdminPage', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ AdminPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), HttpClientModule],
+      providers: [UrlSerializer]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AdminPage);

--- a/dev/Sonos-Kids-Controller-master/src/app/artwork.service.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/artwork.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { ArtworkService } from './artwork.service';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('ArtworkService', () => {
   let service: ArtworkService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule]
+    });
     service = TestBed.inject(ArtworkService);
   });
 

--- a/dev/Sonos-Kids-Controller-master/src/app/edit/edit.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/edit/edit.page.spec.ts
@@ -3,16 +3,22 @@ import { IonicModule } from '@ionic/angular';
 
 import { EditPage } from './edit.page';
 import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing"
+
 
 describe('EditPage', () => {
   let component: EditPage;
   let fixture: ComponentFixture<EditPage>;
+  let httpClient: HttpTestingController;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ EditPage ],
-      imports: [IonicModule.forRoot(), HttpClientModule]
+      imports: [IonicModule.forRoot(), HttpClientModule, RouterTestingModule, HttpClientTestingModule]
     }).compileComponents();
+
+    httpClient = TestBed.inject(HttpTestingController)
 
     fixture = TestBed.createComponent(EditPage);
     component = fixture.componentInstance;
@@ -20,6 +26,7 @@ describe('EditPage', () => {
   }));
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/edit/edit.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/edit/edit.page.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { EditPage } from './edit.page';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('EditPage', () => {
   let component: EditPage;
@@ -10,7 +11,7 @@ describe('EditPage', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ EditPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), HttpClientModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(EditPage);

--- a/dev/Sonos-Kids-Controller-master/src/app/home/home.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/home/home.page.spec.ts
@@ -1,24 +1,31 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { HomePage } from './home.page';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing"
 
 describe('HomePage', () => {
   let component: HomePage;
   let fixture: ComponentFixture<HomePage>;
+  let httpClient: HttpTestingController;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ HomePage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), HttpClientModule, HttpClientTestingModule, RouterTestingModule]
     }).compileComponents();
+
+    httpClient = TestBed.inject(HttpTestingController);
 
     fixture = TestBed.createComponent(HomePage);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/media.service.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/media.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { MediaService } from './media.service';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('MediaService', () => {
   let service: MediaService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule]
+    });
     service = TestBed.inject(MediaService);
   });
 

--- a/dev/Sonos-Kids-Controller-master/src/app/medialist/medialist.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/medialist/medialist.page.spec.ts
@@ -1,24 +1,42 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { MedialistPage } from './medialist.page';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientModule } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing"
 
 describe('MedialistPage', () => {
   let component: MedialistPage;
   let fixture: ComponentFixture<MedialistPage>;
+  let httpClient: HttpTestingController
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ MedialistPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), RouterTestingModule, HttpClientModule, HttpClientTestingModule]
     }).compileComponents();
+
+    httpClient = TestBed.inject(HttpTestingController)
 
     fixture = TestBed.createComponent(MedialistPage);
     component = fixture.componentInstance;
+    // TODO: Artist may be undefined when strictly following TS types, this should be corrected in
+    // medialist.page.ts
+    component.artist = {
+      name: "Baw Batrol",
+      albumCount: "1",
+      cover: "",
+      coverMedia: {
+        type: "",
+        category: ""
+      }
+    }
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/medialist/medialist.page.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/medialist/medialist.page.ts
@@ -56,7 +56,7 @@ export class MedialistPage implements OnInit {
     private activityIndicatorService: ActivityIndicatorService
   ) {
     this.route.queryParams.subscribe(params => {
-      if (this.router.getCurrentNavigation().extras.state) {
+      if (this.router.getCurrentNavigation()?.extras.state?.artist) {
         this.artist = this.router.getCurrentNavigation().extras.state.artist;
         if (this.router.getCurrentNavigation().extras.state?.resume === "resume") {
           this.resume = true;

--- a/dev/Sonos-Kids-Controller-master/src/app/player.service.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/player.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { PlayerService } from './player.service';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('PlayerService', () => {
   let service: PlayerService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule]
+    });
     service = TestBed.inject(PlayerService);
   });
 

--- a/dev/Sonos-Kids-Controller-master/src/app/player/player.page.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/player/player.page.spec.ts
@@ -1,24 +1,35 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { PlayerPage } from './player.page';
+import { HttpClientModule } from '@angular/common/http';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('PlayerPage', () => {
   let component: PlayerPage;
   let fixture: ComponentFixture<PlayerPage>;
+  let httpClient: HttpTestingController;
 
-  beforeEach(async(() => {
+  beforeEach(() => {
     TestBed.configureTestingModule({
       declarations: [ PlayerPage ],
-      imports: [IonicModule.forRoot()]
+      imports: [IonicModule.forRoot(), HttpClientModule, HttpClientTestingModule, RouterTestingModule]
     }).compileComponents();
 
+    httpClient = TestBed.inject(HttpTestingController)
+    
     fixture = TestBed.createComponent(PlayerPage);
     component = fixture.componentInstance;
+    component.media = {
+      type: "",
+      category: ""
+    }
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
+    httpClient.expectOne("http://localhost:8200/api/sonos")
     expect(component).toBeTruthy();
   });
 });

--- a/dev/Sonos-Kids-Controller-master/src/app/player/player.page.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/player/player.page.ts
@@ -70,7 +70,7 @@ export class PlayerPage implements OnInit {
     this.show$ = this.mediaService.show$;
     this.mupihat$ = this.mediaService.mupihat$;
     this.route.queryParams.subscribe((params) => {
-      if (this.router.getCurrentNavigation().extras.state.media) {
+      if (this.router.getCurrentNavigation()?.extras.state?.media) {
         this.media = this.router.getCurrentNavigation().extras.state.media;
         if (this.media.category === "resume") {
           this.resumePlay = true;

--- a/dev/Sonos-Kids-Controller-master/src/app/spotify.service.spec.ts
+++ b/dev/Sonos-Kids-Controller-master/src/app/spotify.service.spec.ts
@@ -1,12 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 
 import { SpotifyService } from './spotify.service';
+import { HttpClientModule } from '@angular/common/http';
 
 describe('SpotifyService', () => {
   let service: SpotifyService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule]
+    });
     service = TestBed.inject(SpotifyService);
   });
 


### PR DESCRIPTION
This is a follow-up PR to #56 (should be reviewed & merged after that one).

In this PR, the frontend tests are fixed so they all pass. Almost all changes are in `*.spec.ts` files so they don't affect the production build. There are minor changes in three `*.ts` files where I added [optional chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html) to better respect potential `null` variables.