### PR TITLE
Make local debugging of Angular app possible

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -40,6 +40,9 @@
     "containerUser": "codespace",
     "customizations": {
         "vscode": {
+            "settings": {
+                "files.insertFinalNewline": true
+            },
             "extensions": [
                 "eamodio.gitlens",
                 "devsense.phptools-vscode"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch Edge",
+            "request": "launch",
+            "type": "msedge",
+            "url": "http://localhost:4200",
+            "webRoot": "${workspaceFolder}/dev/Sonos-Kids-Controller-master"
+        },
+        {
+            "name": "Launch Chrome",
+            "request": "launch",
+            "type": "chrome",
+            "url": "http://localhost:4200",
+            "webRoot": "${workspaceFolder}/dev/Sonos-Kids-Controller-master"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributing changes to the MuPiBox source code is easy thanks to GitHub codespa
 1. Fork this repository.
 2. Start a codespace session.
 3. The box UI located in `dev/Sonos-Kids-Controller-master`
-    - Run `npm install` the first time. To start the server, run `npm build`, create a `config.json` file in the `server/config` subfolder, fill it with `{"spotify": { "clientId": "", "clientSecret": "" }}`, and then run `npm start`
+    - Run `npm install` the first time. To start the development server, copy the `config/templates/www.json` as `config.json` to the `server/config` subfolder, and then run `npm run serve-backend` and `npm run serve-frontend` while being in the `dev/Sonos-Kids-Controller-master` folder.
 4. The Admin interface is located in `AdminInterface/www`.
     - Use `php -S 127.0.0.1:8000` to start a development server.
 5. Create a git branch, commit and push your changes.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Contributing changes to the MuPiBox source code is easy thanks to GitHub codespa
 1. Fork this repository.
 2. Start a codespace session.
 3. The box UI located in `dev/Sonos-Kids-Controller-master`
-    - Run `npm install` the first time. To start the development server, copy the `config/templates/www.json` as `config.json` to the `server/config` subfolder, and then run `npm run serve-backend` and `npm run serve-frontend` while being in the `dev/Sonos-Kids-Controller-master` folder.
+    - Run `npm install` the first time. To start the development server, copy the `config/templates/www.json` as `config.json` and the `monitor.json` files to the `server/config` subfolder, and then run `npm run serve-backend` and `npm run serve-frontend` while being in the `dev/Sonos-Kids-Controller-master` folder.
 4. The Admin interface is located in `AdminInterface/www`.
     - Use `php -S 127.0.0.1:8000` to start a development server.
 5. Create a git branch, commit and push your changes.

--- a/dev/Sonos-Kids-Controller-master/.gitignore
+++ b/dev/Sonos-Kids-Controller-master/.gitignore
@@ -1,3 +1,10 @@
+# Config files of MupiBox.
+server/config/config.json
+server/config/active_data.json
+server/config/data.json
+server/config/monitor.json
+
+
 # Specifies intentionally untracked files to ignore when using Git
 # http://git-scm.com/docs/gitignore
 
@@ -31,7 +38,4 @@ npm-debug.log*
 /plugins
 /www
 /deploy
-
-server/config/data.json
-config.json
 

--- a/dev/Sonos-Kids-Controller-master/angular.json
+++ b/dev/Sonos-Kids-Controller-master/angular.json
@@ -70,6 +70,12 @@
                 }
               ]
             },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "sourceMap": true,
+              "namedChunks": true
+            },
             "ci": {
               "progress": false
             }
@@ -84,10 +90,11 @@
             "production": {
               "browserTarget": "app:build:production"
             },
-            "ci": {
-              "progress": false
+            "development": {
+              "browserTarget": "app:build:development"
             }
-          }
+          },
+          "defaultConfiguration": "development"
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",

--- a/dev/Sonos-Kids-Controller-master/package.json
+++ b/dev/Sonos-Kids-Controller-master/package.json
@@ -5,6 +5,8 @@
     "homepage": "https://github.com/Thyraz/Sonos-Kids-Controller",
     "scripts": {
         "ng": "ng",
+        "serve-backend": "NODE_ENV=development node server.js",
+        "serve-frontend": "ng serve",
         "start": "node server.js",
         "build": "ionic build --prod",
         "deploy": "ionic build --prod",

--- a/dev/Sonos-Kids-Controller-master/server.js
+++ b/dev/Sonos-Kids-Controller-master/server.js
@@ -377,9 +377,8 @@ app.get('/api/token', (req, res) => {
 });
 
 app.get('/api/sonos', (req, res) => {
-    res.status(200).send({ip: "localhost", port: "8200"})
     // Send server address and port of the node-sonos-http-api instance to the client
-    // res.status(200).send(config['node-sonos-http-api']);
+    res.status(200).send(config['node-sonos-http-api']);
 });
 
 const tryReadFile = (filePath, retries = 3, delayMs = 1000) => {

--- a/dev/Sonos-Kids-Controller-master/server.js
+++ b/dev/Sonos-Kids-Controller-master/server.js
@@ -41,7 +41,6 @@ app.use(express.urlencoded({ extended: false }));
 // production.
 if (process.env.NODE_ENV !== 'development') {
     // Static path to compiled Angular app
-    console.log("Serve www")
     app.use(express.static(path.join(__dirname, 'www')));
 }
 

--- a/dev/Sonos-Kids-Controller-master/server.js
+++ b/dev/Sonos-Kids-Controller-master/server.js
@@ -35,8 +35,16 @@ const resumeLock = '/tmp/.resume.lock';
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
-app.use(express.static(path.join(__dirname, 'www'))); // Static path to compiled Ionic app
-
+// We only want to serve the Angular app as static files in production so that we can start
+// the Angular development server during development to be able to hot-reload and debug.
+// We explicitely check for !== 'development' for now so we do not need to set this env in
+// production.
+console.log("started")
+if (process.env.NODE_ENV !== 'development') {
+    // Static path to compiled Angular app
+    console.log("Serve www")
+    app.use(express.static(path.join(__dirname, 'www')));
+}
 
 // Routes
 app.get('/api/rssfeed', async (req, res) => {
@@ -369,8 +377,9 @@ app.get('/api/token', (req, res) => {
 });
 
 app.get('/api/sonos', (req, res) => {
+    res.status(200).send({ip: "localhost", port: "8200"})
     // Send server address and port of the node-sonos-http-api instance to the client
-    res.status(200).send(config['node-sonos-http-api']);
+    // res.status(200).send(config['node-sonos-http-api']);
 });
 
 const tryReadFile = (filePath, retries = 3, delayMs = 1000) => {

--- a/dev/Sonos-Kids-Controller-master/server.js
+++ b/dev/Sonos-Kids-Controller-master/server.js
@@ -39,7 +39,6 @@ app.use(express.urlencoded({ extended: false }));
 // the Angular development server during development to be able to hot-reload and debug.
 // We explicitely check for !== 'development' for now so we do not need to set this env in
 // production.
-console.log("started")
 if (process.env.NODE_ENV !== 'development') {
     // Static path to compiled Angular app
     console.log("Serve www")

--- a/dev/Sonos-Kids-Controller-master/tsconfig.json
+++ b/dev/Sonos-Kids-Controller-master/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "compileOnSave": false,
+  "compileOnSave": true,
   "compilerOptions": {
     "baseUrl": "./",
     "outDir": "./dist/out-tsc",


### PR DESCRIPTION
This is a follow-up PR to #57 and should only be reviewed and merged after that one.

This PR mostly adapts some configuration files to ensure that bringing up local debugging servers with hot-reload is possible so local debugging of the typescript code is possible.
There is one change in `server.js` to prevent serving of the built Angular app in development mode so that the hot-reloaded `ng serve` variant can be used. I took care that this change does not affect the production behavior of `server.js`.

