### PR TITLE
Simple Dockerfile to test box UI in a production setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -138,6 +138,7 @@ RUN apt-get update && \
 RUN rm -R /var/www/*
 RUN unzip $mupisrc/AdminInterface/release/www.zip -d /var/www/
 RUN ln -s /home/dietpi/MuPiBox/media/cover /var/www/cover
+RUN echo "www-data ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/www-data
 RUN chown -R www-data:www-data /var/www/
 RUN chmod -R 755 /var/www/
 RUN chown -R dietpi:www-data /home/dietpi/MuPiBox/media/cover

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,14 +17,16 @@ RUN apt-get update && \
     unzip \
     && rm -rf /var/lib/apt/lists/*
 
+# Setup nodejs.
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+
+# Add dietpi user.
 RUN groupadd -r dietpi && useradd -r -g dietpi dietpi
 RUN groupadd -r gpio
+
+# Add repo source.
 USER dietpi
-
-# RUN touch /home/dietpi/.bashrc
-
 ARG mupisrc=/home/dietpi/MuPiBoxSource
-
 COPY ./AdminInterface $mupisrc/AdminInterface
 COPY ./autosetup  $mupisrc/autosetup
 COPY ./bin  $mupisrc/bin
@@ -33,14 +35,12 @@ COPY ./dev  $mupisrc/dev
 COPY ./media  $mupisrc/media
 COPY ./scripts  $mupisrc/scripts
 COPY ./themes  $mupisrc/themes
-
 USER root
 
 # Needed for "Tracker "idealTree" already exists" error not happening
 WORKDIR /home/dietpi
 
-# Setup nodejs.
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+# Install nodejs packages.
 RUN npm install -g @ionic/cli
 RUN npm install -g pm2
 RUN pm2 startup
@@ -114,7 +114,7 @@ RUN mv $mupisrc/bin/librespot/dev_0.5_20240905/librespot-64bit /usr/bin/librespo
 RUN mv $mupisrc/bin/fbv/fbv_64 /usr/bin/fbv
 RUN chmod 755 /usr/bin/fbv /usr/bin/librespot
 
-# Copy media files.
+# TODO: Copy media files.
 # RUN mv -f $mupisrc/config/templates/splash.txt /boot/splash.txt
 # RUN wget https://gitlab.com/DarkElvenAngel/initramfs-splash/-/raw/master/boot/initramfs.img -O /boot/initramfs.img
 # RUN cp $mupisrc/media/images/goodbye.png /home/dietpi/MuPiBox/sysmedia/images/goodbye.png
@@ -136,16 +136,14 @@ RUN apt-get update && \
     lighttpd \
     && rm -rf /var/lib/apt/lists/*
 RUN rm -R /var/www/*
-RUN unzip $mupisrc/AdminInterface/release/www.zip -d /var/www/
+RUN unzip $mupisrc/AdminInterface/release/www.zip -d /var/www/html
 RUN ln -s /home/dietpi/MuPiBox/media/cover /var/www/cover
+
+# Rights etc. for www-data.
 RUN echo "www-data ALL=(ALL:ALL) NOPASSWD: ALL" | tee /etc/sudoers.d/www-data
 RUN chown -R www-data:www-data /var/www/
 RUN chmod -R 755 /var/www/
 RUN chown -R dietpi:www-data /home/dietpi/MuPiBox/media/cover
-
-# RUN chmod +x $mupisrc/autosetup/autosetup.sh
-# USER dietpi
-# RUN $mupisrc/autosetup/autosetup.sh uselocal
 
 EXPOSE 8200
 EXPOSE 5005

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,155 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    sudo \
+    whiptail \
+    curl \
+    wget \
+    cron \
+    jq \
+    mplayer \
+    nodejs \
+    npm \
+    git \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -r dietpi && useradd -r -g dietpi dietpi
+RUN groupadd -r gpio
+USER dietpi
+
+# RUN touch /home/dietpi/.bashrc
+
+ARG mupisrc=/home/dietpi/MuPiBoxSource
+
+COPY ./AdminInterface $mupisrc/AdminInterface
+COPY ./autosetup  $mupisrc/autosetup
+COPY ./bin  $mupisrc/bin
+COPY ./config  $mupisrc/config
+COPY ./dev  $mupisrc/dev
+COPY ./media  $mupisrc/media
+COPY ./scripts  $mupisrc/scripts
+COPY ./themes  $mupisrc/themes
+
+USER root
+
+# Needed for "Tracker "idealTree" already exists" error not happening
+WORKDIR /home/dietpi
+
+# Setup nodejs.
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash
+RUN npm install -g @ionic/cli
+RUN npm install -g pm2
+RUN pm2 startup
+
+# Create dirs.
+RUN mkdir -p /home/dietpi/.mupibox
+RUN mkdir -p /home/dietpi/MuPiBox/tts_files
+RUN mkdir -p /home/dietpi/.mupibox/chromium_cache
+RUN mkdir -p /home/dietpi/MuPiBox/sysmedia/sound
+RUN mkdir -p /home/dietpi/.cache/spotify
+RUN mkdir /home/dietpi/MuPiBox/sysmedia/images
+RUN mkdir /home/dietpi/MuPiBox/media
+RUN mkdir /home/dietpi/MuPiBox/media/audiobook
+RUN mkdir /home/dietpi/MuPiBox/media/music
+RUN mkdir /home/dietpi/MuPiBox/media/other
+RUN mkdir /home/dietpi/MuPiBox/media/cover
+RUN mkdir /home/dietpi/MuPiBox/themes
+RUN mkdir -p /home/dietpi/.mupibox/Sonos-Kids-Controller-master/
+RUN mkdir /usr/local/bin/mupibox
+RUN mkdir /etc/mupibox
+RUN mkdir /var/log/mupibox/
+
+RUN mv -f $mupisrc/config/templates/mupiboxconfig.json "/etc/mupibox/mupiboxconfig.json"
+RUN chown root:www-data /etc/mupibox/mupiboxconfig.json
+RUN chmod 775 /etc/mupibox/mupiboxconfig.json
+
+# Install mplayer wrapper
+WORKDIR /home/dietpi/.mupibox
+RUN git clone https://github.com/derhuerst/mplayer-wrapper
+RUN cp $mupisrc/dev/customize/mplayer-wrapper/index.js /home/dietpi/.mupibox/mplayer-wrapper/index.js
+WORKDIR /home/dietpi/.mupibox/mplayer-wrapper
+RUN npm install
+
+# Install google tts.
+WORKDIR /home/dietpi/.mupibox
+RUN git clone https://github.com/zlargon/google-tts
+WORKDIR /home/dietpi/.mupibox/google-tts/
+RUN npm install --save
+# RUN npm audit fix
+# RUN npm test
+
+# Frontend.
+RUN cp $mupisrc/bin/nodejs/deploy.zip /home/dietpi/.mupibox/Sonos-Kids-Controller-master/sonos-kids-controller.zip
+RUN mkdir -p /home/dietpi/.mupibox/Sonos-Kids-Controller-master
+# TODO: Why does this throw an error?
+RUN unzip /home/dietpi/.mupibox/Sonos-Kids-Controller-master/sonos-kids-controller.zip -d /home/dietpi/.mupibox/Sonos-Kids-Controller-master/; exit 0
+RUN rm /home/dietpi/.mupibox/Sonos-Kids-Controller-master/sonos-kids-controller.zip
+RUN mkdir -p /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/
+RUN cp $mupisrc/config/templates/www.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/config.json
+RUN cp $mupisrc/config/templates/monitor.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/monitor.json
+WORKDIR /home/dietpi/.mupibox/Sonos-Kids-Controller-master 
+RUN npm install
+RUN pm2 start server.js
+RUN pm2 save
+
+# Spotify player.
+WORKDIR /home/dietpi/.mupibox
+RUN wget https://github.com/amueller-tech/spotifycontroller/archive/main.zip
+RUN unzip main.zip
+RUN rm main.zip
+WORKDIR /home/dietpi/.mupibox/spotifycontroller-main
+RUN cp $mupisrc/config/templates/spotifycontroller.json /home/dietpi/.mupibox/spotifycontroller-main/config/config.json
+RUN cp $mupisrc/bin/nodejs/spotify-control.js /home/dietpi/.mupibox/spotifycontroller-main/spotify-control.js
+RUN ln -s /etc/mupibox/mupiboxconfig.json /home/dietpi/.mupibox/spotifycontroller-main/config/mupiboxconfig.json
+RUN npm install 
+RUN pm2 start spotify-control.js
+RUN pm2 save
+
+# Copy binaries.
+RUN mv $mupisrc/bin/librespot/dev_0.5_20240905/librespot-64bit /usr/bin/librespot
+RUN mv $mupisrc/bin/fbv/fbv_64 /usr/bin/fbv
+RUN chmod 755 /usr/bin/fbv /usr/bin/librespot
+
+# Copy media files.
+# RUN mv -f $mupisrc/config/templates/splash.txt /boot/splash.txt
+# RUN wget https://gitlab.com/DarkElvenAngel/initramfs-splash/-/raw/master/boot/initramfs.img -O /boot/initramfs.img
+# RUN cp $mupisrc/media/images/goodbye.png /home/dietpi/MuPiBox/sysmedia/images/goodbye.png
+# RUN mv -f $mupisrc/media/images/splash.png /boot/splash.png
+# RUN cp $mupisrc/media/images/MuPiLogo.jpg /home/dietpi/MuPiBox/sysmedia/images/MuPiLogo.jpg
+# RUN cp $mupisrc/media/sound/shutdown.wav /home/dietpi/MuPiBox/sysmedia/sound/shutdown.wav
+# RUN cp $mupisrc/media/sound/startup.wav /home/dietpi/MuPiBox/sysmedia/sound/startup.wav
+# RUN cp $mupisrc/media/sound/low.wav /home/dietpi/MuPiBox/sysmedia/sound/low.wav
+# RUN cp $mupisrc/media/sound/button_shutdown.wav /home/dietpi/MuPiBox/sysmedia/sound/button_shutdown.wav
+# RUN cp $mupisrc/media/images/installation.jpg /home/dietpiMuPiBox/sysmedia/images/installation.jpg
+# RUN cp $mupisrc/media/images/battery_low.jpg /home/dietpi/MuPiBox/sysmedia/images/battery_low.jpg
+
+# TODO: Copy themes.
+
+# Activate admin interface.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    php \
+    lighttpd \
+    && rm -rf /var/lib/apt/lists/*
+RUN rm -R /var/www/*
+RUN unzip $mupisrc/AdminInterface/release/www.zip -d /var/www/
+RUN ln -s /home/dietpi/MuPiBox/media/cover /var/www/cover
+RUN chown -R www-data:www-data /var/www/
+RUN chmod -R 755 /var/www/
+RUN chown -R dietpi:www-data /home/dietpi/MuPiBox/media/cover
+
+# RUN chmod +x $mupisrc/autosetup/autosetup.sh
+# USER dietpi
+# RUN $mupisrc/autosetup/autosetup.sh uselocal
+
+EXPOSE 8200
+EXPOSE 5005
+EXPOSE 80
+
+WORKDIR /
+COPY ./docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Please visit official website  https://mupibox.de/anleitungen/installationsanlei
 - Youtube Downloader MeTube (https://github.com/alexta69/metube/pkgs/container/metube)
   
 ## Contributing
-Contributing changes to the MuPiBox source code is easy thanks to GitHub codespaces that allow you to develop inside the browser without needing to set up a local development environment.
+All contributions, e.g., reporting issues etc., are welcome.
+
+If you want to contribute changes to the MuPiBox source code is easy thanks to GitHub codespaces that allow you to develop inside the browser without needing to set up a local development environment.
 1. Fork this repository.
 2. Start a codespace session.
 3. The box UI located in `dev/Sonos-Kids-Controller-master`
@@ -49,4 +51,4 @@ Contributing changes to the MuPiBox source code is easy thanks to GitHub codespa
 5. Create a git branch, commit and push your changes.
 6. Create a pull request for your changes.
 
-Of course, other contributions, e.g., reporting issues etc., are also welcome.
+The Dockerfile in the root directory allows you to test your changes in a production setting (make sure to run `deploy.sh` first). Currently, only the box UI can be tested this way.

--- a/dev/Sonos-Kids-Controller-master/.gitignore
+++ b/dev/Sonos-Kids-Controller-master/.gitignore
@@ -1,8 +1,5 @@
 # Config files of MupiBox.
-server/config/config.json
-server/config/active_data.json
-server/config/data.json
-server/config/monitor.json
+server/config/*.json
 
 
 # Specifies intentionally untracked files to ignore when using Git

--- a/dev/Sonos-Kids-Controller-master/deploy.sh
+++ b/dev/Sonos-Kids-Controller-master/deploy.sh
@@ -3,26 +3,31 @@
 #cleanup
 rm -rf deploy
 
-# build personal web app
-ionic build --prod
+# Build the Angular app.
+npm run build
 
 # Pause execution to see if the build process worked
 read -p "Press Enter to resume ..."
 
 # copy everything to deploy directory
 mkdir deploy
+# Copy Angular frontend app.
 cp -Rp www deploy/
-mkdir deploy/server
-mkdir deploy/server/config
-cp -p server/config/config-example.json  deploy/server/config/
+# Copy network.json.
+mkdir -p deploy/server/config
+cp -p server/config/network.json  deploy/server/config/
+# Copy the backend-js app.
 cp -p server.js deploy/
 cp -p package-deploy.json deploy/package.json
 cp -p README.md deploy/
 
 # archive
 cd deploy
-zip -r ../../sonos-kids-controller.zip .
+zip -r ../../deploy.zip .
 cd ..
+
+# Deploy to bin folder.
+cp ../deploy.zip ../../bin/nodejs/deploy.zip -f
 
 #cleanup
 rm -rf deploy

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,52 +1,5 @@
 #!/bin/bash
 
-# Create some files we need.
-# echo '{
-# 	"ip": "",
-#         "host": "",
-#         "wifi": "",
-#         "wifisignal": "",
-#         "wifilink": ""
-# }' > /tmp/network.json
-
-# services="mupi_check_internet mupi_change_checker librespot smbd mupi_startstop pulseaudio"
-
-# for service_file in ${services}; do
-#   full_service_file=/etc/systemd/system/${service_file}.service
-#   if [ -f "$service_file" ]; then
-#     # Extract the ExecStart command from the service file
-#     exec_start=$(grep -E '^ExecStart=' "$service_file" | cut -d'=' -f2)
-
-#     if [ -n "$exec_start" ]; then
-#       echo "Starting service defined in $service_file: $exec_start"
-#       bash -c "$exec_start"
-#     else
-#       echo "No ExecStart command found in $service_file"
-#     fi
-#   fi
-# done
-
-# bash -c /usr/local/bin/mupibox/startup.sh
-
-# # Start js servers (and box frontend served by them).
-# pm2 resurrect
-
-
-
-# service mupi_wifi start
-# service mupi_check_internet start
-# service mupi_check_monitor start
-# service mupi_change_checker start
-# service mupi_idle_shutdown start
-# service librespot start
-
-# service smbd start
-# service mupi_startstop start
-# service pulseaudio start
-# service mupi_splash start
-# service mupi_powerled start
-# service dietpi-dashboard start
-
 cd /home/dietpi/.mupibox/Sonos-Kids-Controller-master 
 pm2 start server.js
 cd /home/dietpi/.mupibox/spotifycontroller-main

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Create some files we need.
+# echo '{
+# 	"ip": "",
+#         "host": "",
+#         "wifi": "",
+#         "wifisignal": "",
+#         "wifilink": ""
+# }' > /tmp/network.json
+
+# services="mupi_check_internet mupi_change_checker librespot smbd mupi_startstop pulseaudio"
+
+# for service_file in ${services}; do
+#   full_service_file=/etc/systemd/system/${service_file}.service
+#   if [ -f "$service_file" ]; then
+#     # Extract the ExecStart command from the service file
+#     exec_start=$(grep -E '^ExecStart=' "$service_file" | cut -d'=' -f2)
+
+#     if [ -n "$exec_start" ]; then
+#       echo "Starting service defined in $service_file: $exec_start"
+#       bash -c "$exec_start"
+#     else
+#       echo "No ExecStart command found in $service_file"
+#     fi
+#   fi
+# done
+
+# bash -c /usr/local/bin/mupibox/startup.sh
+
+# # Start js servers (and box frontend served by them).
+# pm2 resurrect
+
+
+
+# service mupi_wifi start
+# service mupi_check_internet start
+# service mupi_check_monitor start
+# service mupi_change_checker start
+# service mupi_idle_shutdown start
+# service librespot start
+
+# service smbd start
+# service mupi_startstop start
+# service pulseaudio start
+# service mupi_splash start
+# service mupi_powerled start
+# service dietpi-dashboard start
+
+cd /home/dietpi/.mupibox/Sonos-Kids-Controller-master 
+pm2 start server.js
+cd /home/dietpi/.mupibox/spotifycontroller-main
+pm2 start spotify-control.js
+
+/etc/init.d/lighttpd start
+
+# Run cmd with forwarded args.
+exec "$@"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Music player with touch screen.",
   "scripts": {
     "docker-build": "docker build -t mupibox .",
-    "docker-start": "docker run -it -p 80:80 -p 8200:8200 -p 5005:5005 mupibox:latest bash"
+    "docker-start": "docker run -it -v ./dev/Sonos-Kids-Controller-master/server/:/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/ -p 80:80 -p 8200:8200 -p 5005:5005 mupibox:latest bash"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mupibox",
+  "version": "1.0.0",
+  "description": "Music player with touch screen.",
+  "scripts": {
+    "docker-build": "docker build -t mupibox .",
+    "docker-start": "docker run -it -p 80:80 -p 8200:8200 -p 5005:5005 mupibox:latest bash"
+  },
+  "repository": {
+    "type": "git",
+    "url": " "
+  },
+  "keywords": [
+    "mupi",
+    "music",
+    "rss feed",
+    "spotify",
+    "raspberry pi",
+    "touch screen"
+  ],
+  "author": "MupiBox Team",
+  "license": "MIT"
+}


### PR DESCRIPTION
This PR adds a simple Dockerfile to test the box UI + js backend server in a production setting.

PHP-Admin page and other services do not yet work. Also, the image is not based on dietpi since this proved too difficult for now since dietpi does not provide a pre-built image.
Finally, I would have liked to use the `autosetup.sh` script in the Dockerfile but this also proved too difficult since that is relying on a dietpi base system.