### PR TITLE
Fix duplicate shutdown sound

### DIFF
--- a/config/services/mupi_startstop.service
+++ b/config/services/mupi_startstop.service
@@ -5,7 +5,7 @@ Description=Run Scripts at Start and Stop
 Type=oneshot
 RemainAfterExit=true
 ExecStart=/usr/local/bin/mupibox/mupi_startup.sh
-ExecStop=/usr/local/bin/mupibox/mupi_shutdown.sh
+ExecStop=/bin/bash -c '[ -z "$DISABLE_MUPI_START_STOP" ] && /usr/local/bin/mupibox/mupi_shutdown.sh'
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/mupibox/mupi_shutdown.sh
+++ b/scripts/mupibox/mupi_shutdown.sh
@@ -46,7 +46,10 @@ if [ "${TELEGRAM}" ] && [ ${#TELEGRAM_CHATID} -ge 1 ] && [ ${#TELEGRAM_TOKEN} -g
 	/usr/bin/python3 /usr/local/bin/mupibox/telegram_send_message.py "MuPiBox shutdown" &
 fi
 
-service mupi_powerled stop 
+service mupi_powerled stop
+
+# disable execution of mupi_startstop service on shutdown again
+systemctl set-environment DISABLE_MUPI_START_STOP=1
 
 #sudo /usr/local/bin/mupibox/./setting_update.sh
 #sudo sh -c 'su - dietpi -s /usr/local/bin/mupibox/shutdown_sound.sh'

--- a/scripts/mupihat/mupihat_automation.sh
+++ b/scripts/mupihat/mupihat_automation.sh
@@ -25,7 +25,6 @@ if [ "${BAT_CONNECTED}" -eq 1 ]; then
 					echo "Battery state low"
 				elif [ "${STATE}" = "SHUTDOWN" ]; then
 					echo "Battery state to low - shutdown initiated"
-					systemctl kill mupi_startstop
 					/usr/local/bin/mupibox/./mupi_shutdown.sh ${BATTERY_LOW}
 					poweroff
 				fi


### PR DESCRIPTION
Fixed duplicate shutdown sound for low battery shutdown and mqtt shutdown.

`systemctl kill mupi_startstop` in `mupihat_automation.sh` did not work, the service was still active and then triggerd the `mupi_shutdown.sh` again.