### PR TITLE
Allow keyboard to be hidden

### DIFF
--- a/src/frontend-box/src/app/add/add.page.ts
+++ b/src/frontend-box/src/app/add/add.page.ts
@@ -77,6 +77,7 @@ export class AddPage implements OnInit, AfterViewInit {
   aPartOfAllMax: number
   index: number
   activityIndicatorVisible = false
+  isKeyboardVisible: any
 
   constructor(
     private mediaService: MediaService,
@@ -145,22 +146,22 @@ export class AddPage implements OnInit, AfterViewInit {
       theme: 'hg-theme-default hg-theme-ios',
       layout: {
         default: [
-          'q w e r t z u i o p ü',
+          'q w e r t z u i o p ü {collapse}',
           'a s d f g h j k l ö ä',
           '{shift} y x c v b n m {shift}',
           '{alt} , {space} . {bksp}',
         ],
         shift: [
-          'Q W E R T Z U I O P Ü',
+          'Q W E R T Z U I O P Ü {collapse}',
           'A S D F G H J K L Ö Ä',
           '{shiftactivated} Y X C V B N M {shift}',
-          '{alt} , {space} . {bksp}',
+          '{alt} , {space} . {bksp}'
         ],
         alt: [
-          '1 2 3 4 5 6 7 8 9 0 =',
+          '1 2 3 4 5 6 7 8 9 0 = {collapse}',
           `% @ # $ § & * ° ^ / \\ ' "`,
           '_ ~ - + ; : { } [ ] ( )',
-          '{default} ! {space} ? {bksp}',
+          '{default} ! {space} ? {bksp}'
         ],
       },
       display: {
@@ -175,6 +176,7 @@ export class AddPage implements OnInit, AfterViewInit {
         '{space}': ' ',
         '{default}': 'ABC',
         '{back}': '⇦',
+        '{collapse}': '▼',
       },
     })
 
@@ -215,6 +217,13 @@ export class AddPage implements OnInit, AfterViewInit {
   focusChanged(event: any) {
     this.selectedInputElem = event.target
 
+    if (!this.isKeyboardVisible) {
+      const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
+      if (keyboardElement) {
+        keyboardElement.style.display = 'block';
+        this.isKeyboardVisible = true;
+      }
+    }
     this.keyboard.setOptions({
       disableCaretPositioning: false,
       inputName: event.target.name,
@@ -266,6 +275,13 @@ export class AddPage implements OnInit, AfterViewInit {
     let layout: string
 
     switch (button) {
+      case '{collapse}':
+        const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
+        if (keyboardElement) {
+          keyboardElement.style.display = 'none';
+          this.isKeyboardVisible = false;
+        }
+        return;
       case '{shift}':
       case '{shiftactivated}':
       case '{default}':
@@ -623,5 +639,9 @@ export class AddPage implements OnInit, AfterViewInit {
             labelcover?.length > 0 ||
             cover?.length > 0))
     }
+  }
+
+  toggleKeyboard() {
+    this.handleLayoutChange('{collapse}');
   }
 }

--- a/src/frontend-box/src/app/add/add.page.ts
+++ b/src/frontend-box/src/app/add/add.page.ts
@@ -635,10 +635,6 @@ export class AddPage implements OnInit, AfterViewInit {
     }
   }
 
-  toggleKeyboard() {
-    this.handleLayoutChange('{collapse}');
-  }
-
   private showKeyboard() {
     const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
     if (keyboardElement) {

--- a/src/frontend-box/src/app/add/add.page.ts
+++ b/src/frontend-box/src/app/add/add.page.ts
@@ -77,7 +77,7 @@ export class AddPage implements OnInit, AfterViewInit {
   aPartOfAllMax: number
   index: number
   activityIndicatorVisible = false
-  isKeyboardVisible: boolean
+  isKeyboardVisible = false
 
   constructor(
     private mediaService: MediaService,
@@ -179,6 +179,11 @@ export class AddPage implements OnInit, AfterViewInit {
         '{collapse}': '▼',
       },
     })
+
+    const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
+    if (keyboardElement) {
+      keyboardElement.style.display = 'none';
+    }
 
     this.selectedInputElem = document.querySelector('ion-input:first-child')
 

--- a/src/frontend-box/src/app/add/add.page.ts
+++ b/src/frontend-box/src/app/add/add.page.ts
@@ -77,7 +77,7 @@ export class AddPage implements OnInit, AfterViewInit {
   aPartOfAllMax: number
   index: number
   activityIndicatorVisible = false
-  isKeyboardVisible: any
+  isKeyboardVisible: boolean
 
   constructor(
     private mediaService: MediaService,

--- a/src/frontend-box/src/app/add/add.page.ts
+++ b/src/frontend-box/src/app/add/add.page.ts
@@ -180,11 +180,7 @@ export class AddPage implements OnInit, AfterViewInit {
       },
     })
 
-    const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
-    if (keyboardElement) {
-      keyboardElement.style.display = 'none';
-    }
-
+    this.hideKeyboard();
     this.selectedInputElem = document.querySelector('ion-input:first-child')
 
     this.validate()
@@ -223,12 +219,9 @@ export class AddPage implements OnInit, AfterViewInit {
     this.selectedInputElem = event.target
 
     if (!this.isKeyboardVisible) {
-      const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
-      if (keyboardElement) {
-        keyboardElement.style.display = 'block';
-        this.isKeyboardVisible = true;
-      }
+      this.showKeyboard();
     }
+
     this.keyboard.setOptions({
       disableCaretPositioning: false,
       inputName: event.target.name,
@@ -281,11 +274,7 @@ export class AddPage implements OnInit, AfterViewInit {
 
     switch (button) {
       case '{collapse}':
-        const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
-        if (keyboardElement) {
-          keyboardElement.style.display = 'none';
-          this.isKeyboardVisible = false;
-        }
+        this.hideKeyboard();
         return;
       case '{shift}':
       case '{shiftactivated}':
@@ -648,5 +637,21 @@ export class AddPage implements OnInit, AfterViewInit {
 
   toggleKeyboard() {
     this.handleLayoutChange('{collapse}');
+  }
+
+  private showKeyboard() {
+    const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
+    if (keyboardElement) {
+      keyboardElement.style.display = 'block';
+      this.isKeyboardVisible = true;
+    }
+  }
+
+  private hideKeyboard() {
+    const keyboardElement = document.querySelector('.simple-keyboard') as HTMLElement;
+    if (keyboardElement) {
+      keyboardElement.style.display = 'none';
+      this.isKeyboardVisible = false;
+    }
   }
 }


### PR DESCRIPTION
I have the issue on my 5 inch display, that the keyboard blocks the add and cancel buttons, 

![image](https://github.com/user-attachments/assets/58edd917-a145-4267-a4c8-0447544db76d)



this PR fixes the issue by allowing the keyboard to be collapsible. It also hides it by default and shows it as soon as any text input field is selected