### PR TITLE
changed get monitor to vcgencmd

### DIFF
--- a/scripts/mupibox/get_monitor.sh
+++ b/scripts/mupibox/get_monitor.sh
@@ -23,9 +23,9 @@ do
                 MONITOR=$(sudo -H -u root bash -c "vcgencmd display_power")
                                 MONITOR=(${MONITOR##*=})
                                 if [ ${MONITOR} == "0" ]; then
-                                        /usr/bin/cat <<< $(/usr/bin/jq --arg v "OFF" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
+                                        /usr/bin/cat <<< $(/usr/bin/jq --arg v "Off" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
                                 elif [ ${MONITOR} == "1"  ]; then
-                                        //usr/bin/cat <<< $(/usr/bin/jq --arg v "ON" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
+                                        //usr/bin/cat <<< $(/usr/bin/jq --arg v "On" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
         fi
 
 	sleep 1

--- a/scripts/mupibox/get_monitor.sh
+++ b/scripts/mupibox/get_monitor.sh
@@ -20,11 +20,12 @@ do
                 sudo chown dietpi:dietpi ${MONITOR_FILE}
                 /usr/bin/cat <<< $(/usr/bin/jq -n --arg v "On" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
         else
-                MONITOR=$(sudo -H -u dietpi bash -c "DISPLAY=:0 xset q | grep 'Monitor'")
-				MONITOR=$(echo ${MONITOR} | awk '{print $3}')
-				if [ ${MONITOR} != "" ]; then
-					/usr/bin/cat <<< $(/usr/bin/jq --arg v "${MONITOR}" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
-				fi
+                MONITOR=$(sudo -H -u root bash -c "vcgencmd display_power")
+                                MONITOR=(${MONITOR##*=})
+                                if [ ${MONITOR} == "0" ]; then
+                                        /usr/bin/cat <<< $(/usr/bin/jq --arg v "OFF" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
+                                elif [ ${MONITOR} == "1"  ]; then
+                                        //usr/bin/cat <<< $(/usr/bin/jq --arg v "ON" '.monitor = $v' ${MONITOR_FILE}) >  ${MONITOR_FILE}
         fi
 
 	sleep 1


### PR DESCRIPTION
Fixes https://github.com/splitti/MuPiBox/issues/117: changed to vcgencmd because the old mechanism didn't work properly