### PR TITLE
Internet check auf Port 443

### DIFF
--- a/scripts/mupibox/check_network.py
+++ b/scripts/mupibox/check_network.py
@@ -1,6 +1,6 @@
 import socket
 
-def internet(host="1.1.1.1", port=53, timeout=10):
+def internet(host="1.1.1.1", port=443, timeout=10):
     try:
         socket.setdefaulttimeout(timeout)
         socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))


### PR DESCRIPTION
Da in einigen Umgebungen Port 53 blockiert sein kann, wäre es besser auf Port 443 zu testen.