### PR TITLE
fix: make artist clickable even if cover could not be loaded

### DIFF
--- a/src/frontend-box/src/app/swiper/swiper.component.html
+++ b/src/frontend-box/src/app/swiper/swiper.component.html
@@ -5,7 +5,7 @@
           <ion-row class="img-row">
             <ion-col size="12">
               <ion-card [class.circle-card]="roundImages()">
-                <img (click)="this.elementClicked.emit(currentData)" draggable="false" style="-user-select: none;" ondragstart="return false;" src="{{currentData.imgSrc | async}}">
+                <img (click)="this.elementClicked.emit(currentData)" draggable="false" style="-user-select: none; width: 100%; height: 100%;" ondragstart="return false;" src="{{currentData.imgSrc | async}}">
               </ion-card>
             </ion-col>
           </ion-row>


### PR DESCRIPTION
I debugged quite a while to find out why my local media was not playing. Eventually, I found that the cover logo was not loading properly and hence the image was only 16*16px in the top left corner. This change makes sure that the image will always take up the whole space.