### PR TITLE
Quiet Hours — Per-Weekday Zeitfenster (Homework / Bedtime)

### DIFF
--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -471,6 +471,45 @@ if( $_POST['fan_control'] )
   $CHANGE_TXT = $CHANGE_TXT."<li>Playtime limit settings saved (player restarting...)</li>";
   $change = 2;
   }
+ if( $_POST['quiethours_save'] )
+  {
+  if( !isset($data["quietHours"]) || !is_array($data["quietHours"]) )
+   {
+   $data["quietHours"] = array(
+    "enabled" => false,
+    "maxOverrunMinutes" => 10,
+    "schedule" => array("mon"=>array(),"tue"=>array(),"wed"=>array(),"thu"=>array(),"fri"=>array(),"sat"=>array(),"sun"=>array()),
+   );
+   }
+  $data["quietHours"]["enabled"] = (isset($_POST['quiethours_enabled']) && $_POST['quiethours_enabled'] === '1');
+  $data["quietHours"]["maxOverrunMinutes"] = max(0, min(60, intval($_POST['quiethours_maxOverrunMinutes'])));
+  $quiethours_days = array('mon','tue','wed','thu','fri','sat','sun');
+  $quiethours_window_count = 0;
+  foreach( $quiethours_days as $d )
+   {
+   $rawWindows = isset($_POST['quiet_windows'][$d]) && is_array($_POST['quiet_windows'][$d]) ? $_POST['quiet_windows'][$d] : array();
+   $cleaned = array();
+   foreach( $rawWindows as $w )
+    {
+    if( !is_array($w) ) continue;
+    $from = isset($w['from']) ? trim($w['from']) : '';
+    $to = isset($w['to']) ? trim($w['to']) : '';
+    // Skip incomplete rows (so add-row-then-don't-fill doesn't pollute config).
+    if( $from === '' || $to === '' ) continue;
+    if( !preg_match('/^([01][0-9]|2[0-3]):[0-5][0-9]$/', $from) ) continue;
+    if( !preg_match('/^([01][0-9]|2[0-3]):[0-5][0-9]$/', $to) ) continue;
+    $entry = array('from' => $from, 'to' => $to);
+    $label = isset($w['label']) ? trim($w['label']) : '';
+    if( $label !== '' ) $entry['label'] = $label;
+    $cleaned[] = $entry;
+    $quiethours_window_count++;
+    }
+   $data["quietHours"]["schedule"][$d] = array_values($cleaned);
+   }
+  $playtime_changed = true; // share the player-restart trigger below
+  $CHANGE_TXT = $CHANGE_TXT."<li>Quiet hours saved (".$quiethours_window_count." window(s), player restarting...)</li>";
+  $change = 2;
+  }
  if( $data["shim"]["ledPin"]!=$_POST['ledPin'] && $_POST['ledPin'])
   {
   $data["shim"]["ledPin"]=$_POST['ledPin'];
@@ -791,6 +830,107 @@ $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 			</li>
 		</ul>
 	</details>
+
+	<details id="quiethours">
+		<summary><i class="fa-solid fa-moon"></i> Quiet hours</summary>
+		<ul>
+			<li id="li_1">
+				<h2>About</h2>
+				<p>Define time windows per weekday in which playback is automatically blocked (e.g. homework time, mealtimes, bedtime). Multiple windows per day are supported. Settings take effect after saving (the player is restarted automatically).</p>
+				<p>Set a window's <b>from</b> later than its <b>to</b> to span midnight (e.g. 20:00 → 06:00 covers the night). The optional <b>label</b> is shown to the kid on the block screen.</p>
+			</li>
+			<li id="li_1">
+				<h2>Status</h2>
+				<?php
+				$qh_enabled_state = ( isset($data["quietHours"]["enabled"]) && $data["quietHours"]["enabled"] ) ? true : false;
+				$qh_maxOverrunMinutes = isset($data["quietHours"]["maxOverrunMinutes"]) ? intval($data["quietHours"]["maxOverrunMinutes"]) : 10;
+				$qh_schedule = isset($data["quietHours"]["schedule"]) && is_array($data["quietHours"]["schedule"]) ? $data["quietHours"]["schedule"] : array();
+				echo '<p>Currently: <b>'.($qh_enabled_state ? 'ENABLED' : 'DISABLED').'</b></p>';
+				?>
+				<p>Enable / disable quiet hours:</p>
+				<select name="quiethours_enabled">
+					<option value="1" <?php echo $qh_enabled_state ? 'selected' : ''; ?>>Enabled</option>
+					<option value="0" <?php echo !$qh_enabled_state ? 'selected' : ''; ?>>Disabled</option>
+				</select>
+			</li>
+			<li id="li_1">
+				<h2>Grace period (minutes)</h2>
+				<p>When a quiet window starts, allow up to this many additional minutes for the current track to finish naturally. <b>0</b> = stop immediately at the window boundary. Default: <b>10</b>. Maximum: 60.</p>
+				<input type="number" name="quiethours_maxOverrunMinutes" min="0" max="60" step="1" value="<?php echo $qh_maxOverrunMinutes; ?>"> min
+			</li>
+			<li id="li_1">
+				<h2>Windows per weekday</h2>
+				<p>Use „+ Add window" to add another row to a day. Empty rows are ignored on save.</p>
+				<?php
+				$qh_day_labels = array(
+					'mon' => 'Monday',
+					'tue' => 'Tuesday',
+					'wed' => 'Wednesday',
+					'thu' => 'Thursday',
+					'fri' => 'Friday',
+					'sat' => 'Saturday',
+					'sun' => 'Sunday',
+				);
+				foreach( $qh_day_labels as $key => $label ) {
+					$windows = isset($qh_schedule[$key]) && is_array($qh_schedule[$key]) ? $qh_schedule[$key] : array();
+					echo '<div class="quiet-day-block" style="margin-top:1em;padding:0.5em;border:1px solid #ddd;border-radius:4px;">';
+					echo '<b>'.$label.'</b>';
+					echo '<table class="quiet-windows-table" id="quiet-windows-'.$key.'" style="width:100%;margin-top:0.4em;">';
+					echo '<tr><th>From</th><th>To</th><th>Label (optional)</th><th></th></tr>';
+					$idx = 0;
+					foreach( $windows as $w ) {
+						if( !is_array($w) ) continue;
+						$wFrom = htmlspecialchars(isset($w['from']) ? $w['from'] : '');
+						$wTo = htmlspecialchars(isset($w['to']) ? $w['to'] : '');
+						$wLabel = htmlspecialchars(isset($w['label']) ? $w['label'] : '');
+						echo '<tr class="quiet-window-row">';
+						echo '<td><input type="time" name="quiet_windows['.$key.']['.$idx.'][from]" value="'.$wFrom.'"></td>';
+						echo '<td><input type="time" name="quiet_windows['.$key.']['.$idx.'][to]" value="'.$wTo.'"></td>';
+						echo '<td><input type="text" name="quiet_windows['.$key.']['.$idx.'][label]" value="'.$wLabel.'" placeholder="e.g. Bedtime"></td>';
+						echo '<td><button type="button" class="button_text_red" onclick="removeQuietWindow(this)">×</button></td>';
+						echo '</tr>';
+						$idx++;
+					}
+					echo '</table>';
+					echo '<button type="button" class="button_text" onclick="addQuietWindow(\''.$key.'\')" style="margin-top:0.4em;">+ Add window</button>';
+					echo '</div>';
+				}
+				?>
+			</li>
+			<li class="buttons">
+				<input type="hidden" name="form_id" value="37271" />
+				<input id="saveForm" class="button_text" type="submit" name="quiethours_save" value="Save quiet hours" />
+			</li>
+		</ul>
+	</details>
+
+	<script>
+	function addQuietWindow(day) {
+		var table = document.getElementById('quiet-windows-' + day);
+		// Determine next index by counting existing rows (excluding header).
+		var existingRows = table.querySelectorAll('tr.quiet-window-row');
+		var nextIdx = 0;
+		existingRows.forEach(function(r){
+			var input = r.querySelector('input[name^="quiet_windows[' + day + ']["]');
+			if (input) {
+				var m = input.name.match(/\[(\d+)\]/);
+				if (m) nextIdx = Math.max(nextIdx, parseInt(m[1]) + 1);
+			}
+		});
+		var row = document.createElement('tr');
+		row.className = 'quiet-window-row';
+		row.innerHTML =
+			'<td><input type="time" name="quiet_windows[' + day + '][' + nextIdx + '][from]"></td>' +
+			'<td><input type="time" name="quiet_windows[' + day + '][' + nextIdx + '][to]"></td>' +
+			'<td><input type="text" name="quiet_windows[' + day + '][' + nextIdx + '][label]" placeholder="e.g. Bedtime"></td>' +
+			'<td><button type="button" class="button_text_red" onclick="removeQuietWindow(this)">×</button></td>';
+		table.appendChild(row);
+	}
+	function removeQuietWindow(btn) {
+		var row = btn.closest('tr.quiet-window-row');
+		if (row && row.parentNode) row.parentNode.removeChild(row);
+	}
+	</script>
 
 	<details id="systemsettings">
 		<summary><i class="fa-solid fa-screwdriver-wrench"></i> System settings</summary>

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -449,6 +449,7 @@ if( $_POST['fan_control'] )
    $data["playtimeLimit"] = array(
     "enabled" => false,
     "resetHour" => 0,
+    "maxOverrunMinutes" => 10,
     "limitsMinutes" => array("mon"=>60,"tue"=>60,"wed"=>60,"thu"=>60,"fri"=>60,"sat"=>60,"sun"=>60),
    );
    }
@@ -458,6 +459,7 @@ if( $_POST['fan_control'] )
    }
   $data["playtimeLimit"]["enabled"] = (isset($_POST['playtime_enabled']) && $_POST['playtime_enabled'] === '1');
   $data["playtimeLimit"]["resetHour"] = max(0, min(23, intval($_POST['playtime_resetHour'])));
+  $data["playtimeLimit"]["maxOverrunMinutes"] = max(0, min(60, intval($_POST['playtime_maxOverrunMinutes'])));
   $playtime_days = array('mon','tue','wed','thu','fri','sat','sun');
   foreach( $playtime_days as $d )
    {
@@ -753,6 +755,12 @@ $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 				<h2>Reset hour (0 - 23)</h2>
 				<p>Hour of day at which the counter resets to 0. <b>0</b> = midnight. Use e.g. <b>4</b> if you don't want a reset to interrupt late evening listening.</p>
 				<input type="number" name="playtime_resetHour" min="0" max="23" step="1" value="<?php echo $playtime_resetHour; ?>">
+			</li>
+			<li id="li_1">
+				<h2>Grace period (minutes)</h2>
+				<p>When the daily limit is reached, allow playback to continue for up to this many additional minutes so the current track can finish naturally. The player stops at the next track boundary (for local files / radio / RSS) or at the latest when this grace runs out. <b>0</b> = stop immediately at the limit. Default: <b>10</b>. Maximum: 60.</p>
+				<?php $playtime_maxOverrunMinutes = isset($data["playtimeLimit"]["maxOverrunMinutes"]) ? intval($data["playtimeLimit"]["maxOverrunMinutes"]) : 10; ?>
+				<input type="number" name="playtime_maxOverrunMinutes" min="0" max="60" step="1" value="<?php echo $playtime_maxOverrunMinutes; ?>"> min
 			</li>
 			<li id="li_1">
 				<h2>Daily limit per weekday (minutes)</h2>

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -441,6 +441,34 @@ if( $_POST['fan_control'] )
   $CHANGE_TXT=$CHANGE_TXT."<li>Press Button delay set to ".$_POST['pressDelay']. " seconds</li>";
   $change=2;
   }
+ $playtime_changed = false;
+ if( $_POST['playtime_save'] )
+  {
+  if( !isset($data["playtimeLimit"]) || !is_array($data["playtimeLimit"]) )
+   {
+   $data["playtimeLimit"] = array(
+    "enabled" => false,
+    "resetHour" => 0,
+    "limitsMinutes" => array("mon"=>60,"tue"=>60,"wed"=>60,"thu"=>60,"fri"=>60,"sat"=>60,"sun"=>60),
+   );
+   }
+  if( !isset($data["playtimeLimit"]["limitsMinutes"]) || !is_array($data["playtimeLimit"]["limitsMinutes"]) )
+   {
+   $data["playtimeLimit"]["limitsMinutes"] = array("mon"=>60,"tue"=>60,"wed"=>60,"thu"=>60,"fri"=>60,"sat"=>60,"sun"=>60);
+   }
+  $data["playtimeLimit"]["enabled"] = (isset($_POST['playtime_enabled']) && $_POST['playtime_enabled'] === '1');
+  $data["playtimeLimit"]["resetHour"] = max(0, min(23, intval($_POST['playtime_resetHour'])));
+  $playtime_days = array('mon','tue','wed','thu','fri','sat','sun');
+  foreach( $playtime_days as $d )
+   {
+   $field = 'playtime_limit_' . $d;
+   $val = isset($_POST[$field]) ? intval($_POST[$field]) : 60;
+   $data["playtimeLimit"]["limitsMinutes"][$d] = max(0, min(1440, $val));
+   }
+  $playtime_changed = true;
+  $CHANGE_TXT = $CHANGE_TXT."<li>Playtime limit settings saved (player restarting...)</li>";
+  $change = 2;
+  }
  if( $data["shim"]["ledPin"]!=$_POST['ledPin'] && $_POST['ledPin'])
   {
   $data["shim"]["ledPin"]=$_POST['ledPin'];
@@ -569,7 +597,12 @@ if( $_POST['fan_control'] )
    exec("sudo mv /tmp/.mupiboxconfig.json /etc/mupibox/mupiboxconfig.json");
    exec("sudo /usr/local/bin/mupibox/./setting_update.sh");
   }
-  
+ if( $playtime_changed )
+  {
+  // Player caches mupiboxconfig.json at startup via require(); restart so the new playtime values take effect.
+  exec("sudo -i -u dietpi pm2 restart spotify-control");
+  }
+
 $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 ?>
 
@@ -691,6 +724,62 @@ $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 				<input type="hidden" name="form_id" value="37271" />
 
 				<input id="saveForm" class="button_text" type="submit" name="idletime" value="Submit idle time" />
+			</li>
+		</ul>
+	</details>
+
+	<details id="playtimelimit">
+		<summary><i class="fa-solid fa-hourglass-half"></i> Daily playtime limit</summary>
+		<ul>
+			<li id="li_1">
+				<h2>About</h2>
+				<p>Caps the total daily listening time on the box. When the limit is reached, playback stops and new playback is refused until the next day. Set a day to <b>0</b> to block playback completely on that day. Settings take effect after saving (the player is restarted automatically).</p>
+			</li>
+			<li id="li_1">
+				<h2>Status</h2>
+				<?php
+				$playtime_enabled_state = ( isset($data["playtimeLimit"]["enabled"]) && $data["playtimeLimit"]["enabled"] ) ? true : false;
+				$playtime_resetHour = isset($data["playtimeLimit"]["resetHour"]) ? intval($data["playtimeLimit"]["resetHour"]) : 0;
+				$playtime_limits = isset($data["playtimeLimit"]["limitsMinutes"]) && is_array($data["playtimeLimit"]["limitsMinutes"]) ? $data["playtimeLimit"]["limitsMinutes"] : array();
+				echo '<p>Currently: <b>'.($playtime_enabled_state ? 'ENABLED' : 'DISABLED').'</b></p>';
+				?>
+				<p>Enable / disable the daily limit:</p>
+				<select name="playtime_enabled">
+					<option value="1" <?php echo $playtime_enabled_state ? 'selected' : ''; ?>>Enabled</option>
+					<option value="0" <?php echo !$playtime_enabled_state ? 'selected' : ''; ?>>Disabled</option>
+				</select>
+			</li>
+			<li id="li_1">
+				<h2>Reset hour (0 - 23)</h2>
+				<p>Hour of day at which the counter resets to 0. <b>0</b> = midnight. Use e.g. <b>4</b> if you don't want a reset to interrupt late evening listening.</p>
+				<input type="number" name="playtime_resetHour" min="0" max="23" step="1" value="<?php echo $playtime_resetHour; ?>">
+			</li>
+			<li id="li_1">
+				<h2>Daily limit per weekday (minutes)</h2>
+				<p>Set <b>0</b> to block playback entirely on that day. Maximum 1440 (= 24 h).</p>
+				<table class="version">
+					<tr><th>Day</th><th>Minutes per day</th></tr>
+					<?php
+					$playtime_day_labels = array(
+						'mon' => 'Monday',
+						'tue' => 'Tuesday',
+						'wed' => 'Wednesday',
+						'thu' => 'Thursday',
+						'fri' => 'Friday',
+						'sat' => 'Saturday',
+						'sun' => 'Sunday',
+					);
+					foreach( $playtime_day_labels as $key => $label )
+						{
+						$val = isset($playtime_limits[$key]) ? intval($playtime_limits[$key]) : 60;
+						echo '<tr><td>'.$label.'</td><td><input type="number" name="playtime_limit_'.$key.'" min="0" max="1440" step="1" value="'.$val.'"> min</td></tr>';
+						}
+					?>
+				</table>
+			</li>
+			<li class="buttons">
+				<input type="hidden" name="form_id" value="37271" />
+				<input id="saveForm" class="button_text" type="submit" name="playtime_save" value="Save playtime settings" />
 			</li>
 		</ul>
 	</details>

--- a/AdminInterface/www/mupi.php
+++ b/AdminInterface/www/mupi.php
@@ -836,8 +836,16 @@ $CHANGE_TXT=$CHANGE_TXT."</ul></div>";
 		<ul>
 			<li id="li_1">
 				<h2>About</h2>
-				<p>Define time windows per weekday in which playback is automatically blocked (e.g. homework time, mealtimes, bedtime). Multiple windows per day are supported. Settings take effect after saving (the player is restarted automatically).</p>
-				<p>Set a window's <b>from</b> later than its <b>to</b> to span midnight (e.g. 20:00 → 06:00 covers the night). The optional <b>label</b> is shown to the kid on the block screen.</p>
+				<p>Define time windows per weekday during which playback is automatically blocked (e.g. homework, mealtimes, bedtime). Multiple windows per day are supported.</p>
+				<p><b>How a window is interpreted:</b></p>
+				<ul style="margin-left:1.2em;list-style:disc;">
+					<li>A window <b>belongs to the day it starts on</b>.</li>
+					<li>If <b>from</b> is later than <b>to</b>, the window automatically continues into the next morning.</li>
+					<li><b>Example:</b> a single entry on <i>Monday</i> with <code>from 20:00 → to 08:00</code> blocks playback Monday evening <i>and</i> Tuesday morning until 08:00. You do <b>not</b> need a separate Tuesday entry for the same night.</li>
+					<li>Multiple windows on the same day combine — e.g. add a <code>14:00 → 16:00 (Homework)</code> alongside <code>20:00 → 08:00 (Bedtime)</code> to block both periods.</li>
+					<li>The optional <b>label</b> is shown to the kid on the block screen (e.g. „Homework", „Bedtime").</li>
+				</ul>
+				<p>Settings take effect after saving (the player is restarted automatically).</p>
 			</li>
 			<li id="li_1">
 				<h2>Status</h2>

--- a/config/templates/mupiboxconfig.json
+++ b/config/templates/mupiboxconfig.json
@@ -268,6 +268,7 @@
 	"playtimeLimit": {
 		"enabled": false,
 		"resetHour": 0,
+		"maxOverrunMinutes": 10,
 		"limitsMinutes": {
 			"mon": 60,
 			"tue": 60,

--- a/config/templates/mupiboxconfig.json
+++ b/config/templates/mupiboxconfig.json
@@ -279,6 +279,19 @@
 			"sun": 60
 		}
 	},
+	"quietHours": {
+		"enabled": false,
+		"maxOverrunMinutes": 10,
+		"schedule": {
+			"mon": [],
+			"tue": [],
+			"wed": [],
+			"thu": [],
+			"fri": [],
+			"sat": [],
+			"sun": []
+		}
+	},
 	"shim": {
 		"poweroffPin": "4",
 		"triggerPin": "17",

--- a/config/templates/mupiboxconfig.json
+++ b/config/templates/mupiboxconfig.json
@@ -265,6 +265,19 @@
 		"idleDisplayOff": "10",
 		"pressDelay": "2"
 	    },
+	"playtimeLimit": {
+		"enabled": false,
+		"resetHour": 0,
+		"limitsMinutes": {
+			"mon": 60,
+			"tue": 60,
+			"wed": 60,
+			"thu": 60,
+			"fri": 60,
+			"sat": 60,
+			"sun": 60
+		}
+	},
 	"shim": {
 		"poweroffPin": "4",
 		"triggerPin": "17",

--- a/src/backend-api/src/models/mupibox-config.model.ts
+++ b/src/backend-api/src/models/mupibox-config.model.ts
@@ -1,4 +1,4 @@
-import type { PlaytimeLimitConfig } from './playtime.model'
+import type { PlaytimeLimitConfig, QuietHoursConfig } from './playtime.model'
 
 export interface MupiboxConfig {
   spotify?: {
@@ -6,5 +6,6 @@ export interface MupiboxConfig {
     [key: string]: unknown
   }
   playtimeLimit?: PlaytimeLimitConfig
+  quietHours?: QuietHoursConfig
   [key: string]: unknown
 }

--- a/src/backend-api/src/models/mupibox-config.model.ts
+++ b/src/backend-api/src/models/mupibox-config.model.ts
@@ -1,7 +1,10 @@
+import type { PlaytimeLimitConfig } from './playtime.model'
+
 export interface MupiboxConfig {
   spotify?: {
     disableScraperForPlaylists?: boolean
     [key: string]: unknown
   }
+  playtimeLimit?: PlaytimeLimitConfig
   [key: string]: unknown
 }

--- a/src/backend-api/src/models/playtime.model.ts
+++ b/src/backend-api/src/models/playtime.model.ts
@@ -1,0 +1,26 @@
+export type PlaytimeDayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
+
+export type PlaytimeLimitsMinutes = Partial<Record<PlaytimeDayKey, number>>
+
+export interface PlaytimeLimitConfig {
+  enabled: boolean
+  resetHour?: number
+  limitsMinutes?: PlaytimeLimitsMinutes
+}
+
+export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
+
+export interface PlaytimeStatusDisabled {
+  enabled: false
+}
+
+export interface PlaytimeStatusEnabled {
+  enabled: true
+  date: string
+  dayKey: PlaytimeDayKey
+  limitMinutes: number
+  usedSeconds: number
+  remainingSeconds: number
+  blocked: boolean
+  resetHour: number
+}

--- a/src/backend-api/src/models/playtime.model.ts
+++ b/src/backend-api/src/models/playtime.model.ts
@@ -9,10 +9,32 @@ export interface PlaytimeLimitConfig {
   limitsMinutes?: PlaytimeLimitsMinutes
 }
 
-// 'normal'  → under daily limit, playback unrestricted
-// 'grace'   → over limit, current track allowed to finish; new commands blocked
+// === Quiet Hours ===
+
+export interface QuietHoursWindow {
+  from: string // HH:MM
+  to: string // HH:MM, may be < from to span midnight
+  label?: string
+}
+
+export type QuietHoursSchedule = Partial<Record<PlaytimeDayKey, QuietHoursWindow[]>>
+
+export interface QuietHoursConfig {
+  enabled: boolean
+  maxOverrunMinutes?: number
+  schedule?: QuietHoursSchedule
+}
+
+// === Combined playback status ===
+
+// 'normal'  → no restriction, playback unrestricted
+// 'grace'   → over a limit (playtime or quiet entry), current track allowed to finish
 // 'blocked' → fully stopped, frontend overlays the screen
 export type PlaytimePlayState = 'normal' | 'grace' | 'blocked'
+
+// Identifies *what* is currently restricting playback (when state !== 'normal').
+// 'playtime' = daily-limit-based, 'quiet' = time-window-based.
+export type PlaybackBlockSource = 'playtime' | 'quiet'
 
 export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
 
@@ -23,6 +45,9 @@ export interface PlaytimeStatusDisabled {
 export interface PlaytimeStatusEnabled {
   enabled: true
   state: PlaytimePlayState
+  blockSource: PlaybackBlockSource | null
+  // Set when blockSource === 'quiet' and the active window has a label.
+  quietLabel?: string
   date: string
   dayKey: PlaytimeDayKey
   limitMinutes: number

--- a/src/backend-api/src/models/playtime.model.ts
+++ b/src/backend-api/src/models/playtime.model.ts
@@ -5,8 +5,14 @@ export type PlaytimeLimitsMinutes = Partial<Record<PlaytimeDayKey, number>>
 export interface PlaytimeLimitConfig {
   enabled: boolean
   resetHour?: number
+  maxOverrunMinutes?: number
   limitsMinutes?: PlaytimeLimitsMinutes
 }
+
+// 'normal'  → under daily limit, playback unrestricted
+// 'grace'   → over limit, current track allowed to finish; new commands blocked
+// 'blocked' → fully stopped, frontend overlays the screen
+export type PlaytimePlayState = 'normal' | 'grace' | 'blocked'
 
 export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
 
@@ -16,11 +22,12 @@ export interface PlaytimeStatusDisabled {
 
 export interface PlaytimeStatusEnabled {
   enabled: true
+  state: PlaytimePlayState
   date: string
   dayKey: PlaytimeDayKey
   limitMinutes: number
   usedSeconds: number
   remainingSeconds: number
-  blocked: boolean
+  graceEndsInSeconds: number
   resetHour: number
 }

--- a/src/backend-api/src/server.ts
+++ b/src/backend-api/src/server.ts
@@ -10,6 +10,7 @@ import ky from 'ky'
 import xmlparser from 'xml-js'
 import { LogRequest, LogResponse } from './models/log.model'
 import type { MupiboxConfig } from './models/mupibox-config.model'
+import type { PlaytimeStatus } from './models/playtime.model'
 import { ServerConfig } from './models/server.model'
 import type { SpotifyValidationRequest, SpotifyValidationResponse } from './models/spotify-api.model'
 import { SpotifyApiService } from './services/spotify-api.service'
@@ -62,6 +63,7 @@ const wlanFile = `${configBasePath}/wlan.json`
 const monitorFile = `${configBasePath}/monitor.json`
 const albumstopFile = `${configBasePath}/albumstop.json`
 const mupihat = '/tmp/mupihat.json'
+const playtimeFile = '/tmp/playtime.json'
 const dataLock = '/tmp/.data.lock'
 const resumeLock = '/tmp/.resume.lock'
 
@@ -161,6 +163,26 @@ app.get('/api/mupihat', (_req, res) => {
       }
     })
   }
+})
+
+// Playback time tracking written by backend-player to /tmp/playtime.json (tmpfs).
+// Missing/unreadable file means the player hasn't ticked yet or the feature is off —
+// either way, surfaces as "disabled" so the frontend can hide the UI safely.
+app.get('/api/playtime', (_req, res) => {
+  const disabled: PlaytimeStatus = { enabled: false }
+  if (!fs.existsSync(playtimeFile)) {
+    res.json(disabled)
+    return
+  }
+  jsonfile.readFile(playtimeFile, (error, data) => {
+    if (error) {
+      console.log(`${new Date().toLocaleString()}: [MuPiBox-Server] Error /api/playtime read playtime.json`)
+      console.log(`${new Date().toLocaleString()}: [MuPiBox-Server] ${error}`)
+      res.json(disabled)
+    } else {
+      res.json(data)
+    }
+  })
 })
 
 app.get('/api/activeresume', (_req, res) => {

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -122,17 +122,25 @@ player.on('track-change', () => {
     cmdCall('/usr/bin/python3 /usr/local/bin/mupibox/telegram_Track_Local.py')
 })
 
-// Playtime grace period: stop at the next natural mplayer break point
+// Playtime + Quiet-Hours grace: stop at the next natural mplayer break point
 // (start of next track, or end of playlist). Spotify doesn't surface these
-// events, so for Spotify the grace timeout in playtimeTick() is the only stop trigger.
+// events, so for Spotify the grace timeout in the tick is the only stop trigger.
+// Both sub-systems are checked independently — a single track-change can
+// finalize either or both if both happen to be in grace simultaneously.
 player.on('track-change', () => {
   if (playtimeState.state === 'grace') {
     finalizePlaytimeBlock('next track would start during grace period')
+  }
+  if (quietHoursState.state === 'grace') {
+    finalizeQuietHoursBlock('next track would start during grace period')
   }
 })
 player.on('playlist-finish', () => {
   if (playtimeState.state === 'grace') {
     finalizePlaytimeBlock('playlist finished during grace period')
+  }
+  if (quietHoursState.state === 'grace') {
+    finalizeQuietHoursBlock('playlist finished during grace period')
   }
 })
 
@@ -222,6 +230,64 @@ function readPlaytimeConfig() {
   }
 }
 
+// === Quiet Hours ===
+const QUIET_DEFAULT_SCHEDULE = { mon: [], tue: [], wed: [], thu: [], fri: [], sat: [], sun: [] }
+
+function readQuietHoursConfig() {
+  const raw = muPiBoxConfig?.quietHours || {}
+  const maxOverrunMinutes =
+    Number.isInteger(raw.maxOverrunMinutes) && raw.maxOverrunMinutes >= 0 && raw.maxOverrunMinutes <= 60
+      ? raw.maxOverrunMinutes
+      : 10
+  return {
+    enabled: raw.enabled === true,
+    maxOverrunMinutes,
+    schedule: { ...QUIET_DEFAULT_SCHEDULE, ...(raw.schedule || {}) },
+  }
+}
+
+// 'HH:MM' → minutes since midnight, or null if invalid.
+function parseHHMMToMinutes(hhmm) {
+  if (typeof hhmm !== 'string') return null
+  const m = hhmm.match(/^(\d{1,2}):(\d{2})$/)
+  if (!m) return null
+  const h = Number(m[1])
+  const min = Number(m[2])
+  if (h < 0 || h > 23 || min < 0 || min > 59) return null
+  return h * 60 + min
+}
+
+// Returns the active quiet window object {from, to, label?} that contains "now",
+// or null if no window applies. Windows belong to the day they start on; a
+// midnight-spanning window (from > to) covers from `from` of its day until `to`
+// of the next day.
+function findActiveQuietWindow(now, schedule) {
+  const todayKey = PLAYTIME_DAY_KEYS[now.getDay()]
+  const yesterdayKey = PLAYTIME_DAY_KEYS[(now.getDay() + 6) % 7]
+  const nowMinutes = now.getHours() * 60 + now.getMinutes()
+
+  for (const w of schedule[todayKey] || []) {
+    const fromMin = parseHHMMToMinutes(w.from)
+    const toMin = parseHHMMToMinutes(w.to)
+    if (fromMin === null || toMin === null) continue
+    if (fromMin < toMin) {
+      if (nowMinutes >= fromMin && nowMinutes < toMin) return w
+    } else if (fromMin > toMin) {
+      // Same-day half of a midnight-spanning window
+      if (nowMinutes >= fromMin) return w
+    }
+    // fromMin === toMin: zero-length, skip
+  }
+  // Yesterday's wrapping windows (the to-half lands in today's early hours)
+  for (const w of schedule[yesterdayKey] || []) {
+    const fromMin = parseHHMMToMinutes(w.from)
+    const toMin = parseHHMMToMinutes(w.to)
+    if (fromMin === null || toMin === null) continue
+    if (fromMin > toMin && nowMinutes < toMin) return w
+  }
+  return null
+}
+
 // Reset-hour shifts when "today" begins. With resetHour=4, Sunday 02:00 still counts as Saturday.
 function getLogicalDay(now, resetHour) {
   const shifted = new Date(now.getTime() - resetHour * 3600 * 1000)
@@ -249,6 +315,13 @@ const playtimeState = {
 let playtimeLastCheckpointAt = 0
 let playtimeLastCheckpointSeconds = -1
 
+// Quiet hours uses the same state machine but is purely time-window-driven (no counter).
+const quietHoursState = {
+  state: 'normal',
+  graceEndsAt: null,
+  activeWindow: null, // current window object {from, to, label?} when in_window
+}
+
 function loadPlaytimeCheckpoint() {
   try {
     if (!fs.existsSync(PLAYTIME_CHECKPOINT_PATH)) return
@@ -268,25 +341,53 @@ function loadPlaytimeCheckpoint() {
   }
 }
 
-function writePlaytimeWorking() {
-  const cfg = readPlaytimeConfig()
-  if (!cfg.enabled) {
+function writeCombinedWorking() {
+  const ptCfg = readPlaytimeConfig()
+  const qhCfg = readQuietHoursConfig()
+
+  if (!ptCfg.enabled && !qhCfg.enabled) {
     fs.writeFile(PLAYTIME_WORKING_PATH, JSON.stringify({ enabled: false }), () => {})
     return
   }
-  const limit = cfg.limitsMinutes[playtimeState.dayKey] ?? 60
-  const graceEndsInSeconds =
+
+  // Combined effective state across both sub-systems
+  let state = 'normal'
+  if (playtimeState.state === 'blocked' || quietHoursState.state === 'blocked') state = 'blocked'
+  else if (playtimeState.state === 'grace' || quietHoursState.state === 'grace') state = 'grace'
+
+  // blockSource: prefer 'quiet' over 'playtime' if both are restricting (more "explainable" to the kid)
+  let blockSource = null
+  if (quietHoursState.state !== 'normal') blockSource = 'quiet'
+  else if (playtimeState.state !== 'normal') blockSource = 'playtime'
+
+  const ptLimit = ptCfg.enabled ? (ptCfg.limitsMinutes[playtimeState.dayKey] ?? 60) : 0
+  const ptGraceEndsInSeconds =
     playtimeState.graceEndsAt !== null ? Math.max(0, Math.ceil((playtimeState.graceEndsAt - Date.now()) / 1000)) : 0
+  const qhGraceEndsInSeconds =
+    quietHoursState.graceEndsAt !== null ? Math.max(0, Math.ceil((quietHoursState.graceEndsAt - Date.now()) / 1000)) : 0
+
   const payload = {
     enabled: true,
-    state: playtimeState.state,
-    date: playtimeState.date,
-    dayKey: playtimeState.dayKey,
-    limitMinutes: limit,
-    usedSeconds: playtimeState.usedSeconds,
-    remainingSeconds: Math.max(0, limit * 60 - playtimeState.usedSeconds),
-    graceEndsInSeconds,
-    resetHour: cfg.resetHour,
+    state,
+    blockSource,
+    playtime: {
+      enabled: ptCfg.enabled,
+      state: playtimeState.state,
+      date: playtimeState.date,
+      dayKey: playtimeState.dayKey,
+      limitMinutes: ptLimit,
+      usedSeconds: playtimeState.usedSeconds,
+      remainingSeconds: ptCfg.enabled ? Math.max(0, ptLimit * 60 - playtimeState.usedSeconds) : 0,
+      graceEndsInSeconds: ptGraceEndsInSeconds,
+      resetHour: ptCfg.resetHour,
+    },
+    quiet: {
+      enabled: qhCfg.enabled,
+      state: quietHoursState.state,
+      inWindow: quietHoursState.activeWindow !== null,
+      ...(quietHoursState.activeWindow?.label ? { label: quietHoursState.activeWindow.label } : {}),
+      graceEndsInSeconds: qhGraceEndsInSeconds,
+    },
   }
   fs.writeFile(PLAYTIME_WORKING_PATH, JSON.stringify(payload), () => {})
 }
@@ -305,10 +406,17 @@ function writePlaytimeCheckpoint() {
 }
 
 // Used by the catch-all to decide whether to refuse new play/resume/skip commands.
-// During grace, the *current* track is allowed to finish but no new playback may start.
-function isPlaytimeBlocked() {
-  return playtimeState.state === 'grace' || playtimeState.state === 'blocked'
+// True if EITHER playtime OR quiet hours is currently restricting playback.
+function isPlaybackBlocked() {
+  return (
+    playtimeState.state === 'grace' ||
+    playtimeState.state === 'blocked' ||
+    quietHoursState.state === 'grace' ||
+    quietHoursState.state === 'blocked'
+  )
 }
+// Backwards-compat alias kept so older call sites keep working.
+const isPlaytimeBlocked = isPlaybackBlocked
 
 // Transition to fully-stopped state. Called from the tick on grace timeout, from the
 // mplayer track-change/playlist-finish handlers, or directly when grace=0.
@@ -323,6 +431,17 @@ function finalizePlaytimeBlock(reason) {
     console.error(`${new Date().toLocaleString()}: [Playtime] Error stopping playback:`, e)
   }
   writePlaytimeCheckpoint()
+}
+
+function finalizeQuietHoursBlock(reason) {
+  console.log(`${new Date().toLocaleString()}: [QuietHours] Finalizing block (${reason})`)
+  quietHoursState.state = 'blocked'
+  quietHoursState.graceEndsAt = null
+  try {
+    stop()
+  } catch (e) {
+    console.error(`${new Date().toLocaleString()}: [QuietHours] Error stopping playback:`, e)
+  }
 }
 
 // Commands that *start or resume* playback. These get blocked when the daily cap is hit.
@@ -343,14 +462,16 @@ function isPlayInitiatingCommand(command) {
   return false
 }
 
-function playtimeTick() {
+// Updates playtimeState only (counter, day rollover, state transitions, SD checkpoint).
+// Working-state file is written separately by writeCombinedWorking once both
+// sub-systems have ticked, so the payload is consistent.
+function playtimeTickStep() {
   const cfg = readPlaytimeConfig()
   if (!cfg.enabled) {
     if (playtimeState.state !== 'normal' || playtimeState.graceEndsAt !== null) {
       playtimeState.state = 'normal'
       playtimeState.graceEndsAt = null
     }
-    writePlaytimeWorking()
     return
   }
   const now = new Date()
@@ -369,13 +490,11 @@ function playtimeTick() {
   if (isActuallyPlaying()) {
     playtimeState.usedSeconds++
   }
-  // State transitions
   const limit = cfg.limitsMinutes[today.dayKey] ?? 60
   const limitSeconds = limit * 60
   const limitReached = playtimeState.usedSeconds >= limitSeconds
   if (limitReached) {
     if (playtimeState.state === 'normal') {
-      // Just-reached transition
       const overrunMs = cfg.maxOverrunMinutes * 60 * 1000
       if (overrunMs > 0) {
         playtimeState.state = 'grace'
@@ -394,9 +513,6 @@ function playtimeTick() {
     }
     // else 'blocked': stay blocked
   }
-  // Working state: every tick (tmpfs, no SD wear)
-  writePlaytimeWorking()
-  // SD checkpoint: every 60s if value changed
   if (
     Date.now() - playtimeLastCheckpointAt >= PLAYTIME_CHECKPOINT_INTERVAL_MS &&
     playtimeState.usedSeconds !== playtimeLastCheckpointSeconds
@@ -405,8 +521,59 @@ function playtimeTick() {
   }
 }
 
+// Updates quietHoursState based on whether "now" falls inside any configured window.
+// Mirror of playtimeTickStep but purely time-window-driven (no counter).
+function quietHoursTickStep() {
+  const cfg = readQuietHoursConfig()
+  if (!cfg.enabled) {
+    if (quietHoursState.state !== 'normal' || quietHoursState.activeWindow !== null) {
+      // User just disabled mid-window: instantly release. Playback isn't auto-started
+      // (it was stopped by the previous block) — kid taps play to resume.
+      quietHoursState.state = 'normal'
+      quietHoursState.graceEndsAt = null
+      quietHoursState.activeWindow = null
+    }
+    return
+  }
+  const now = new Date()
+  const window = findActiveQuietWindow(now, cfg.schedule)
+  if (window) {
+    if (quietHoursState.state === 'normal') {
+      // Just entered a window
+      quietHoursState.activeWindow = window
+      const overrunMs = cfg.maxOverrunMinutes * 60 * 1000
+      if (overrunMs > 0) {
+        quietHoursState.state = 'grace'
+        quietHoursState.graceEndsAt = Date.now() + overrunMs
+        console.log(
+          `${now.toLocaleString()}: [QuietHours] Entered window ${window.from}-${window.to}${window.label ? ` (${window.label})` : ''}. Entering grace period (max ${cfg.maxOverrunMinutes} min).`,
+        )
+      } else {
+        finalizeQuietHoursBlock(`entered window ${window.from}-${window.to} (no grace configured)`)
+      }
+    } else if (quietHoursState.state === 'grace') {
+      if (quietHoursState.graceEndsAt !== null && Date.now() >= quietHoursState.graceEndsAt) {
+        finalizeQuietHoursBlock(`grace period expired (${cfg.maxOverrunMinutes} min)`)
+      }
+    }
+    // 'blocked': stay blocked
+  } else if (quietHoursState.state !== 'normal') {
+    // Just exited a window — release without auto-starting playback
+    console.log(`${now.toLocaleString()}: [QuietHours] Window ended. Playback can resume on user action.`)
+    quietHoursState.state = 'normal'
+    quietHoursState.graceEndsAt = null
+    quietHoursState.activeWindow = null
+  }
+}
+
+function combinedTick() {
+  playtimeTickStep()
+  quietHoursTickStep()
+  writeCombinedWorking()
+}
+
 loadPlaytimeCheckpoint()
-setInterval(playtimeTick, 1000)
+setInterval(combinedTick, 1000)
 
 function writeplayerstatePlay() {
   playerstate = 'play'
@@ -1258,13 +1425,16 @@ app.use((req, res) => {
   log.debug(`${nowDate.toLocaleString()}: [Spotify Control]name: ${command.name}`)
   log.debug(`${nowDate.toLocaleString()}: [Spotify Control]dir: ${command.dir}`)
 
-  // Playtime limit: refuse new playback when the daily cap is reached.
+  // Playtime / Quiet-Hours: refuse new playback when either is restricting.
   // Pause/stop/volume/system commands fall through normally.
-  if (isPlaytimeBlocked() && isPlayInitiatingCommand(command)) {
+  if (isPlaybackBlocked() && isPlayInitiatingCommand(command)) {
+    const inQuiet = quietHoursState.state !== 'normal'
+    const reason = inQuiet ? 'quiet_hours_active' : 'playtime_limit_reached'
+    const tag = inQuiet ? 'QuietHours' : 'Playtime'
     console.log(
-      `${new Date().toLocaleString()}: [Playtime] Rejected command (limit reached): name=${command.name} dir=${command.dir}`,
+      `${new Date().toLocaleString()}: [${tag}] Rejected command (${reason}): name=${command.name} dir=${command.dir}`,
     )
-    res.status(423).send({ status: 'blocked', error: 'playtime_limit_reached' })
+    res.status(423).send({ status: 'blocked', error: reason })
     return
   }
 

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -122,6 +122,20 @@ player.on('track-change', () => {
     cmdCall('/usr/bin/python3 /usr/local/bin/mupibox/telegram_Track_Local.py')
 })
 
+// Playtime grace period: stop at the next natural mplayer break point
+// (start of next track, or end of playlist). Spotify doesn't surface these
+// events, so for Spotify the grace timeout in playtimeTick() is the only stop trigger.
+player.on('track-change', () => {
+  if (playtimeState.state === 'grace') {
+    finalizePlaytimeBlock('next track would start during grace period')
+  }
+})
+player.on('playlist-finish', () => {
+  if (playtimeState.state === 'grace') {
+    finalizePlaytimeBlock('playlist finished during grace period')
+  }
+})
+
 setInterval(() => {
   const cmdVolume = "/usr/bin/amixer sget Master | grep 'Right:'"
   const exec = require('node:child_process').exec
@@ -194,9 +208,16 @@ const PLAYTIME_CHECKPOINT_INTERVAL_MS = 60_000
 function readPlaytimeConfig() {
   const raw = muPiBoxConfig?.playtimeLimit || {}
   const resetHour = Number.isInteger(raw.resetHour) && raw.resetHour >= 0 && raw.resetHour < 24 ? raw.resetHour : 0
+  // Grace period in minutes after the limit is reached during which playback may
+  // continue (current track allowed to finish). 0 = stop immediately at the limit.
+  const maxOverrunMinutes =
+    Number.isInteger(raw.maxOverrunMinutes) && raw.maxOverrunMinutes >= 0 && raw.maxOverrunMinutes <= 60
+      ? raw.maxOverrunMinutes
+      : 10
   return {
     enabled: raw.enabled === true,
     resetHour,
+    maxOverrunMinutes,
     limitsMinutes: { ...PLAYTIME_DEFAULT_LIMITS, ...(raw.limitsMinutes || {}) },
   }
 }
@@ -217,11 +238,13 @@ function isActuallyPlaying() {
   return false
 }
 
+// state machine: 'normal' (under limit) → 'grace' (over limit, current track finishing) → 'blocked' (stopped)
 const playtimeState = {
   date: '',
   dayKey: 'mon',
   usedSeconds: 0,
-  blocked: false,
+  state: 'normal',
+  graceEndsAt: null,
 }
 let playtimeLastCheckpointAt = 0
 let playtimeLastCheckpointSeconds = -1
@@ -251,14 +274,17 @@ function writePlaytimeWorking() {
     return
   }
   const limit = cfg.limitsMinutes[playtimeState.dayKey] ?? 60
+  const graceEndsInSeconds =
+    playtimeState.graceEndsAt !== null ? Math.max(0, Math.ceil((playtimeState.graceEndsAt - Date.now()) / 1000)) : 0
   const payload = {
     enabled: true,
+    state: playtimeState.state,
     date: playtimeState.date,
     dayKey: playtimeState.dayKey,
     limitMinutes: limit,
     usedSeconds: playtimeState.usedSeconds,
     remainingSeconds: Math.max(0, limit * 60 - playtimeState.usedSeconds),
-    blocked: playtimeState.blocked,
+    graceEndsInSeconds,
     resetHour: cfg.resetHour,
   }
   fs.writeFile(PLAYTIME_WORKING_PATH, JSON.stringify(payload), () => {})
@@ -277,12 +303,24 @@ function writePlaytimeCheckpoint() {
   playtimeLastCheckpointSeconds = playtimeState.usedSeconds
 }
 
+// Used by the catch-all to decide whether to refuse new play/resume/skip commands.
+// During grace, the *current* track is allowed to finish but no new playback may start.
 function isPlaytimeBlocked() {
-  const cfg = readPlaytimeConfig()
-  if (!cfg.enabled) return false
-  const today = getLogicalDay(new Date(), cfg.resetHour)
-  const limit = cfg.limitsMinutes[today.dayKey] ?? 60
-  return playtimeState.usedSeconds >= limit * 60
+  return playtimeState.state === 'grace' || playtimeState.state === 'blocked'
+}
+
+// Transition to fully-stopped state. Called from the tick on grace timeout, from the
+// mplayer track-change/playlist-finish handlers, or directly when grace=0.
+function finalizePlaytimeBlock(reason) {
+  log.info(`${new Date().toLocaleString()}: [Playtime] Finalizing block (${reason})`)
+  playtimeState.state = 'blocked'
+  playtimeState.graceEndsAt = null
+  try {
+    stop()
+  } catch (e) {
+    log.error(`${new Date().toLocaleString()}: [Playtime] Error stopping playback:`, e)
+  }
+  writePlaytimeCheckpoint()
 }
 
 // Commands that *start or resume* playback. These get blocked when the daily cap is hit.
@@ -306,18 +344,22 @@ function isPlayInitiatingCommand(command) {
 function playtimeTick() {
   const cfg = readPlaytimeConfig()
   if (!cfg.enabled) {
-    if (playtimeState.blocked) playtimeState.blocked = false
+    if (playtimeState.state !== 'normal' || playtimeState.graceEndsAt !== null) {
+      playtimeState.state = 'normal'
+      playtimeState.graceEndsAt = null
+    }
     writePlaytimeWorking()
     return
   }
   const now = new Date()
   const today = getLogicalDay(now, cfg.resetHour)
-  // Day rollover: reset counter
+  // Day rollover: reset counter and state
   if (today.dateStr !== playtimeState.date) {
     playtimeState.date = today.dateStr
     playtimeState.dayKey = today.dayKey
     playtimeState.usedSeconds = 0
-    playtimeState.blocked = false
+    playtimeState.state = 'normal'
+    playtimeState.graceEndsAt = null
     writePlaytimeCheckpoint()
     log.info(`${now.toLocaleString()}: [Playtime] New day: ${today.dateStr} (${today.dayKey})`)
   }
@@ -325,22 +367,30 @@ function playtimeTick() {
   if (isActuallyPlaying()) {
     playtimeState.usedSeconds++
   }
-  // Check the limit
+  // State transitions
   const limit = cfg.limitsMinutes[today.dayKey] ?? 60
   const limitSeconds = limit * 60
-  const wasBlocked = playtimeState.blocked
-  playtimeState.blocked = playtimeState.usedSeconds >= limitSeconds
-  // Just-blocked transition: stop playback once
-  if (playtimeState.blocked && !wasBlocked) {
-    log.info(
-      `${now.toLocaleString()}: [Playtime] Daily limit reached (${limit} min for ${today.dayKey}). Stopping playback.`,
-    )
-    try {
-      stop()
-    } catch (e) {
-      log.error(`${now.toLocaleString()}: [Playtime] Error stopping playback:`, e)
+  const limitReached = playtimeState.usedSeconds >= limitSeconds
+  if (limitReached) {
+    if (playtimeState.state === 'normal') {
+      // Just-reached transition
+      const overrunMs = cfg.maxOverrunMinutes * 60 * 1000
+      if (overrunMs > 0) {
+        playtimeState.state = 'grace'
+        playtimeState.graceEndsAt = Date.now() + overrunMs
+        log.info(
+          `${now.toLocaleString()}: [Playtime] Daily limit reached (${limit} min for ${today.dayKey}). Entering grace period (max ${cfg.maxOverrunMinutes} min until current track ends).`,
+        )
+        writePlaytimeCheckpoint()
+      } else {
+        finalizePlaytimeBlock(`limit reached (${limit} min, no grace configured)`)
+      }
+    } else if (playtimeState.state === 'grace') {
+      if (playtimeState.graceEndsAt !== null && Date.now() >= playtimeState.graceEndsAt) {
+        finalizePlaytimeBlock(`grace period expired (${cfg.maxOverrunMinutes} min)`)
+      }
     }
-    writePlaytimeCheckpoint()
+    // else 'blocked': stay blocked
   }
   // Working state: every tick (tmpfs, no SD wear)
   writePlaytimeWorking()

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -246,9 +246,13 @@ function loadPlaytimeCheckpoint() {
 
 function writePlaytimeWorking() {
   const cfg = readPlaytimeConfig()
+  if (!cfg.enabled) {
+    fs.writeFile(PLAYTIME_WORKING_PATH, JSON.stringify({ enabled: false }), () => {})
+    return
+  }
   const limit = cfg.limitsMinutes[playtimeState.dayKey] ?? 60
   const payload = {
-    enabled: cfg.enabled,
+    enabled: true,
     date: playtimeState.date,
     dayKey: playtimeState.dayKey,
     limitMinutes: limit,
@@ -303,6 +307,7 @@ function playtimeTick() {
   const cfg = readPlaytimeConfig()
   if (!cfg.enabled) {
     if (playtimeState.blocked) playtimeState.blocked = false
+    writePlaytimeWorking()
     return
   }
   const now = new Date()

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -180,6 +180,177 @@ const currentMeta = {
   volume: 0,
 }
 
+// === Playtime Limit (daily listening cap) ===
+// Per-weekday limit on active playback time. Configured in mupiboxconfig.json
+// under "playtimeLimit". Working state lives in /tmp (tmpfs, no SD wear);
+// a checkpoint on the SD card persists across reboots, written at most every 60s.
+// Config changes require a player restart (consistent with other config in this file).
+const PLAYTIME_DAY_KEYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']
+const PLAYTIME_DEFAULT_LIMITS = { mon: 60, tue: 60, wed: 60, thu: 60, fri: 60, sat: 60, sun: 60 }
+const PLAYTIME_WORKING_PATH = '/tmp/playtime.json'
+const PLAYTIME_CHECKPOINT_PATH = path.join(configBasePath, 'playtime-checkpoint.json')
+const PLAYTIME_CHECKPOINT_INTERVAL_MS = 60_000
+
+function readPlaytimeConfig() {
+  const raw = muPiBoxConfig?.playtimeLimit || {}
+  const resetHour = Number.isInteger(raw.resetHour) && raw.resetHour >= 0 && raw.resetHour < 24 ? raw.resetHour : 0
+  return {
+    enabled: raw.enabled === true,
+    resetHour,
+    limitsMinutes: { ...PLAYTIME_DEFAULT_LIMITS, ...(raw.limitsMinutes || {}) },
+  }
+}
+
+// Reset-hour shifts when "today" begins. With resetHour=4, Sunday 02:00 still counts as Saturday.
+function getLogicalDay(now, resetHour) {
+  const shifted = new Date(now.getTime() - resetHour * 3600 * 1000)
+  const y = shifted.getFullYear()
+  const m = String(shifted.getMonth() + 1).padStart(2, '0')
+  const d = String(shifted.getDate()).padStart(2, '0')
+  return { dateStr: `${y}-${m}-${d}`, dayKey: PLAYTIME_DAY_KEYS[shifted.getDay()] }
+}
+
+function isActuallyPlaying() {
+  if (!currentMeta.currentPlayer) return false
+  if (currentMeta.currentPlayer === 'spotify') return currentMeta.pause === false
+  if (currentMeta.currentPlayer === 'mplayer') return currentMeta.playing === true
+  return false
+}
+
+const playtimeState = {
+  date: '',
+  dayKey: 'mon',
+  usedSeconds: 0,
+  blocked: false,
+}
+let playtimeLastCheckpointAt = 0
+let playtimeLastCheckpointSeconds = -1
+
+function loadPlaytimeCheckpoint() {
+  try {
+    if (!fs.existsSync(PLAYTIME_CHECKPOINT_PATH)) return
+    const data = JSON.parse(fs.readFileSync(PLAYTIME_CHECKPOINT_PATH, 'utf8'))
+    const today = getLogicalDay(new Date(), readPlaytimeConfig().resetHour)
+    if (data && data.date === today.dateStr) {
+      playtimeState.date = data.date
+      playtimeState.dayKey = data.dayKey || today.dayKey
+      playtimeState.usedSeconds = Number(data.usedSeconds) || 0
+      log.info(
+        `${new Date().toLocaleString()}: [Playtime] Resumed counter: ${playtimeState.usedSeconds}s for ${playtimeState.date}`,
+      )
+    }
+  } catch (e) {
+    log.error(`${new Date().toLocaleString()}: [Playtime] Failed to load checkpoint:`, e)
+  }
+}
+
+function writePlaytimeWorking() {
+  const cfg = readPlaytimeConfig()
+  const limit = cfg.limitsMinutes[playtimeState.dayKey] ?? 60
+  const payload = {
+    enabled: cfg.enabled,
+    date: playtimeState.date,
+    dayKey: playtimeState.dayKey,
+    limitMinutes: limit,
+    usedSeconds: playtimeState.usedSeconds,
+    remainingSeconds: Math.max(0, limit * 60 - playtimeState.usedSeconds),
+    blocked: playtimeState.blocked,
+    resetHour: cfg.resetHour,
+  }
+  fs.writeFile(PLAYTIME_WORKING_PATH, JSON.stringify(payload), () => {})
+}
+
+function writePlaytimeCheckpoint() {
+  const payload = {
+    date: playtimeState.date,
+    dayKey: playtimeState.dayKey,
+    usedSeconds: playtimeState.usedSeconds,
+  }
+  fs.writeFile(PLAYTIME_CHECKPOINT_PATH, JSON.stringify(payload), (err) => {
+    if (err) log.error(`${new Date().toLocaleString()}: [Playtime] Failed to write checkpoint:`, err)
+  })
+  playtimeLastCheckpointAt = Date.now()
+  playtimeLastCheckpointSeconds = playtimeState.usedSeconds
+}
+
+function isPlaytimeBlocked() {
+  const cfg = readPlaytimeConfig()
+  if (!cfg.enabled) return false
+  const today = getLogicalDay(new Date(), cfg.resetHour)
+  const limit = cfg.limitsMinutes[today.dayKey] ?? 60
+  return playtimeState.usedSeconds >= limit * 60
+}
+
+// Commands that *start or resume* playback. These get blocked when the daily cap is hit.
+// Pause/stop/volume/system commands are NOT blocked — those should always work.
+function isPlayInitiatingCommand(command) {
+  if (command.name?.includes('spotify:')) return true
+  if (
+    command.dir &&
+    (command.dir.includes('library') ||
+      command.dir.includes('radio') ||
+      command.dir.includes('rss') ||
+      command.dir.includes('say/'))
+  ) {
+    return true
+  }
+  if (['play', 'next', 'previous', 'seek+30', 'seek-30'].includes(command.name)) return true
+  if (command.name?.startsWith('seekpos:')) return true
+  return false
+}
+
+function playtimeTick() {
+  const cfg = readPlaytimeConfig()
+  if (!cfg.enabled) {
+    if (playtimeState.blocked) playtimeState.blocked = false
+    return
+  }
+  const now = new Date()
+  const today = getLogicalDay(now, cfg.resetHour)
+  // Day rollover: reset counter
+  if (today.dateStr !== playtimeState.date) {
+    playtimeState.date = today.dateStr
+    playtimeState.dayKey = today.dayKey
+    playtimeState.usedSeconds = 0
+    playtimeState.blocked = false
+    writePlaytimeCheckpoint()
+    log.info(`${now.toLocaleString()}: [Playtime] New day: ${today.dateStr} (${today.dayKey})`)
+  }
+  // Increment counter only when actually playing
+  if (isActuallyPlaying()) {
+    playtimeState.usedSeconds++
+  }
+  // Check the limit
+  const limit = cfg.limitsMinutes[today.dayKey] ?? 60
+  const limitSeconds = limit * 60
+  const wasBlocked = playtimeState.blocked
+  playtimeState.blocked = playtimeState.usedSeconds >= limitSeconds
+  // Just-blocked transition: stop playback once
+  if (playtimeState.blocked && !wasBlocked) {
+    log.info(
+      `${now.toLocaleString()}: [Playtime] Daily limit reached (${limit} min for ${today.dayKey}). Stopping playback.`,
+    )
+    try {
+      stop()
+    } catch (e) {
+      log.error(`${now.toLocaleString()}: [Playtime] Error stopping playback:`, e)
+    }
+    writePlaytimeCheckpoint()
+  }
+  // Working state: every tick (tmpfs, no SD wear)
+  writePlaytimeWorking()
+  // SD checkpoint: every 60s if value changed
+  if (
+    Date.now() - playtimeLastCheckpointAt >= PLAYTIME_CHECKPOINT_INTERVAL_MS &&
+    playtimeState.usedSeconds !== playtimeLastCheckpointSeconds
+  ) {
+    writePlaytimeCheckpoint()
+  }
+}
+
+loadPlaytimeCheckpoint()
+setInterval(playtimeTick, 1000)
+
 function writeplayerstatePlay() {
   playerstate = 'play'
   fs.writeFile('/tmp/playerstate', playerstate, (err) => {
@@ -1029,6 +1200,17 @@ app.use((req, res) => {
   const command = path.parse(req.url)
   log.debug(`${nowDate.toLocaleString()}: [Spotify Control]name: ${command.name}`)
   log.debug(`${nowDate.toLocaleString()}: [Spotify Control]dir: ${command.dir}`)
+
+  // Playtime limit: refuse new playback when the daily cap is reached.
+  // Pause/stop/volume/system commands fall through normally.
+  if (isPlaytimeBlocked() && isPlayInitiatingCommand(command)) {
+    log.info(
+      `${new Date().toLocaleString()}: [Playtime] Rejected command (limit reached): name=${command.name} dir=${command.dir}`,
+    )
+    res.status(423).send({ status: 'blocked', error: 'playtime_limit_reached' })
+    return
+  }
+
   /*this is the first command to be received. It always includes the device id encoded in between two /*/
   /*check this if we need to transfer the playback to a new device*/
   if (command.name.includes('spotify:')) {

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -258,12 +258,13 @@ function loadPlaytimeCheckpoint() {
       playtimeState.date = data.date
       playtimeState.dayKey = data.dayKey || today.dayKey
       playtimeState.usedSeconds = Number(data.usedSeconds) || 0
-      log.info(
+      // console.log so it shows even when logLevel='error' (the default)
+      console.log(
         `${new Date().toLocaleString()}: [Playtime] Resumed counter: ${playtimeState.usedSeconds}s for ${playtimeState.date}`,
       )
     }
   } catch (e) {
-    log.error(`${new Date().toLocaleString()}: [Playtime] Failed to load checkpoint:`, e)
+    console.error(`${new Date().toLocaleString()}: [Playtime] Failed to load checkpoint:`, e)
   }
 }
 
@@ -312,13 +313,14 @@ function isPlaytimeBlocked() {
 // Transition to fully-stopped state. Called from the tick on grace timeout, from the
 // mplayer track-change/playlist-finish handlers, or directly when grace=0.
 function finalizePlaytimeBlock(reason) {
-  log.info(`${new Date().toLocaleString()}: [Playtime] Finalizing block (${reason})`)
+  // console.log so it shows even when logLevel='error' (the default)
+  console.log(`${new Date().toLocaleString()}: [Playtime] Finalizing block (${reason})`)
   playtimeState.state = 'blocked'
   playtimeState.graceEndsAt = null
   try {
     stop()
   } catch (e) {
-    log.error(`${new Date().toLocaleString()}: [Playtime] Error stopping playback:`, e)
+    console.error(`${new Date().toLocaleString()}: [Playtime] Error stopping playback:`, e)
   }
   writePlaytimeCheckpoint()
 }
@@ -361,7 +363,7 @@ function playtimeTick() {
     playtimeState.state = 'normal'
     playtimeState.graceEndsAt = null
     writePlaytimeCheckpoint()
-    log.info(`${now.toLocaleString()}: [Playtime] New day: ${today.dateStr} (${today.dayKey})`)
+    console.log(`${now.toLocaleString()}: [Playtime] New day: ${today.dateStr} (${today.dayKey})`)
   }
   // Increment counter only when actually playing
   if (isActuallyPlaying()) {
@@ -378,7 +380,7 @@ function playtimeTick() {
       if (overrunMs > 0) {
         playtimeState.state = 'grace'
         playtimeState.graceEndsAt = Date.now() + overrunMs
-        log.info(
+        console.log(
           `${now.toLocaleString()}: [Playtime] Daily limit reached (${limit} min for ${today.dayKey}). Entering grace period (max ${cfg.maxOverrunMinutes} min until current track ends).`,
         )
         writePlaytimeCheckpoint()
@@ -1259,7 +1261,7 @@ app.use((req, res) => {
   // Playtime limit: refuse new playback when the daily cap is reached.
   // Pause/stop/volume/system commands fall through normally.
   if (isPlaytimeBlocked() && isPlayInitiatingCommand(command)) {
-    log.info(
+    console.log(
       `${new Date().toLocaleString()}: [Playtime] Rejected command (limit reached): name=${command.name} dir=${command.dir}`,
     )
     res.status(423).send({ status: 'blocked', error: 'playtime_limit_reached' })

--- a/src/backend-player/src/spotify-control.js
+++ b/src/backend-player/src/spotify-control.js
@@ -524,6 +524,14 @@ function playtimeTickStep() {
 // Updates quietHoursState based on whether "now" falls inside any configured window.
 // Mirror of playtimeTickStep but purely time-window-driven (no counter).
 function quietHoursTickStep() {
+  // AR5-14: parent's allowUntil override suppresses ALL state transitions —
+  // not just blocked-entry. Without this, a quiet window that starts mid-
+  // override would silently mutate state to 'grace' or 'blocked'; the
+  // moment the override ended, the kid would be hit with no grace at all
+  // (state already 'blocked'). Skipping the tick keeps state at 'normal'
+  // throughout the override, so the post-override tick walks the proper
+  // normal -> grace -> blocked path again.
+  if (isAllowOverrideActive()) return
   const cfg = readQuietHoursConfig()
   if (!cfg.enabled) {
     if (quietHoursState.state !== 'normal' || quietHoursState.activeWindow !== null) {

--- a/src/frontend-box/src/app/app.component.html
+++ b/src/frontend-box/src/app/app.component.html
@@ -2,5 +2,8 @@
   @if (monitorOff()) {
     <div class="mupi-monitor-blocker" (click)="$event.stopPropagation()"></div>
   }
+  @if (playtimeBlocked()) {
+    <mupi-playtime-blocked></mupi-playtime-blocked>
+  }
   <ion-router-outlet></ion-router-outlet>
 </ion-app>

--- a/src/frontend-box/src/app/app.component.html
+++ b/src/frontend-box/src/app/app.component.html
@@ -2,6 +2,7 @@
   @if (monitorOff()) {
     <div class="mupi-monitor-blocker" (click)="$event.stopPropagation()"></div>
   }
+  <mupi-playtime-chip></mupi-playtime-chip>
   @if (playtimeBlocked()) {
     <mupi-playtime-blocked></mupi-playtime-blocked>
   }

--- a/src/frontend-box/src/app/app.component.ts
+++ b/src/frontend-box/src/app/app.component.ts
@@ -75,6 +75,9 @@ export class AppComponent {
     // work even if the user listens from the home page (player page unmounted,
     // its in-page saver inert). Backend's composite-key dedup means the entry
     // overwrites any existing resume for the same item.
+    //
+    // Gated on shouldPersistResume() so a wrong-cover-touch right before a
+    // cap doesn't leave a stale entry in the resume swiper.
     effect(() => {
       const status = playtimeService.status()
       if (!status.enabled) {
@@ -86,6 +89,7 @@ export class AppComponent {
       this.prevPlaytimeState = cur
       if (prev === 'unknown' || prev === cur) return
       if (cur !== 'grace' && cur !== 'blocked') return
+      if (!this.currentMediaService.shouldPersistResume()) return
 
       const source = this.currentMediaService.get()
       if (!source) return

--- a/src/frontend-box/src/app/app.component.ts
+++ b/src/frontend-box/src/app/app.component.ts
@@ -38,7 +38,7 @@ export class AppComponent {
     )
     this.playtimeBlocked = computed(() => {
       const s = playtimeService.status()
-      return s.enabled === true && s.blocked
+      return s.enabled === true && s.state === 'blocked'
     })
   }
 }

--- a/src/frontend-box/src/app/app.component.ts
+++ b/src/frontend-box/src/app/app.component.ts
@@ -1,15 +1,21 @@
 import { HttpClient } from '@angular/common/http'
-import { ChangeDetectionStrategy, Component, computed, Signal } from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, effect, Signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone'
 import { distinctUntilChanged, interval, map, Observable, switchMap } from 'rxjs'
 import { environment } from 'src/environments/environment'
+import { CurrentMediaService } from './current-media.service'
+import type { CurrentMPlayer } from './current.mplayer'
+import type { CurrentSpotify } from './current.spotify'
 import { DisplayManagerService } from './display-manager.service'
 import { ExternalPlaybackNavigatorService } from './external-playback-navigator.service'
+import { MediaService } from './media.service'
 import { Monitor } from './monitor'
+import type { PlaytimePlayState } from './playtime.model'
 import { PlaytimeService } from './playtime.service'
 import { PlaytimeBlockedOverlayComponent } from './playtime-blocked-overlay/playtime-blocked-overlay.component'
 import { PlaytimeChipComponent } from './playtime-chip/playtime-chip.component'
+import { buildResumeMedia } from './resume-builder'
 
 @Component({
   selector: 'app-root',
@@ -22,11 +28,22 @@ export class AppComponent {
   protected monitorOff: Signal<boolean>
   protected playtimeBlocked: Signal<boolean>
 
+  // Latest state snapshots — kept fresh by ngOnInit subscriptions on
+  // mediaService.current$/local$ so the resume-on-cap effect can read them
+  // synchronously when a transition fires.
+  private latestSpotify: CurrentSpotify | null = null
+  private latestLocal: CurrentMPlayer | null = null
+  // Track previous playtime state to detect normal -> grace/blocked transitions.
+  // 'unknown' on first tick avoids spurious save before we know the baseline.
+  private prevPlaytimeState: PlaytimePlayState | 'unknown' = 'unknown'
+
   public constructor(
     private http: HttpClient,
     _externalPlaybackNavigator: ExternalPlaybackNavigatorService,
     _displayManager: DisplayManagerService,
     playtimeService: PlaytimeService,
+    private mediaService: MediaService,
+    private currentMediaService: CurrentMediaService,
   ) {
     this.monitorOff = toSignal(
       // 1.5s should be enough to be somewhat "recent".
@@ -40,6 +57,40 @@ export class AppComponent {
     this.playtimeBlocked = computed(() => {
       const s = playtimeService.status()
       return s.enabled === true && s.state === 'blocked'
+    })
+
+    // Keep player-state snapshots fresh. AppComponent is the root component
+    // and lives for the kiosk's lifetime, so these subscriptions never need
+    // teardown; they also cause MediaService to keep its shared polling alive.
+    this.mediaService.current$.subscribe((s) => {
+      this.latestSpotify = s
+    })
+    this.mediaService.local$.subscribe((l) => {
+      this.latestLocal = l
+    })
+
+    // Global resume-on-cap: when playtime/quiet hours transitions
+    // normal -> grace or normal -> blocked, persist a resume entry for the
+    // currently-playing Media. This is what makes "weiterhören wo aufgehört"
+    // work even if the user listens from the home page (player page unmounted,
+    // its in-page saver inert). Backend's composite-key dedup means the entry
+    // overwrites any existing resume for the same item.
+    effect(() => {
+      const status = playtimeService.status()
+      if (!status.enabled) {
+        this.prevPlaytimeState = 'unknown'
+        return
+      }
+      const cur = status.state
+      const prev = this.prevPlaytimeState
+      this.prevPlaytimeState = cur
+      if (prev === 'unknown' || prev === cur) return
+      if (cur !== 'grace' && cur !== 'blocked') return
+
+      const source = this.currentMediaService.get()
+      if (!source) return
+      const resumeMedia = buildResumeMedia(source, this.latestSpotify, this.latestLocal)
+      this.mediaService.addRawResume(resumeMedia)
     })
   }
 }

--- a/src/frontend-box/src/app/app.component.ts
+++ b/src/frontend-box/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http'
-import { ChangeDetectionStrategy, Component, Signal } from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, Signal } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone'
 import { distinctUntilChanged, interval, map, Observable, switchMap } from 'rxjs'
@@ -7,21 +7,25 @@ import { environment } from 'src/environments/environment'
 import { DisplayManagerService } from './display-manager.service'
 import { ExternalPlaybackNavigatorService } from './external-playback-navigator.service'
 import { Monitor } from './monitor'
+import { PlaytimeService } from './playtime.service'
+import { PlaytimeBlockedOverlayComponent } from './playtime-blocked-overlay/playtime-blocked-overlay.component'
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.scss'],
-  imports: [IonApp, IonRouterOutlet],
+  imports: [IonApp, IonRouterOutlet, PlaytimeBlockedOverlayComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
   protected monitorOff: Signal<boolean>
+  protected playtimeBlocked: Signal<boolean>
 
   public constructor(
     private http: HttpClient,
     _externalPlaybackNavigator: ExternalPlaybackNavigatorService,
     _displayManager: DisplayManagerService,
+    playtimeService: PlaytimeService,
   ) {
     this.monitorOff = toSignal(
       // 1.5s should be enough to be somewhat "recent".
@@ -32,5 +36,9 @@ export class AppComponent {
       ),
       { initialValue: false },
     )
+    this.playtimeBlocked = computed(() => {
+      const s = playtimeService.status()
+      return s.enabled === true && s.blocked
+    })
   }
 }

--- a/src/frontend-box/src/app/app.component.ts
+++ b/src/frontend-box/src/app/app.component.ts
@@ -9,12 +9,13 @@ import { ExternalPlaybackNavigatorService } from './external-playback-navigator.
 import { Monitor } from './monitor'
 import { PlaytimeService } from './playtime.service'
 import { PlaytimeBlockedOverlayComponent } from './playtime-blocked-overlay/playtime-blocked-overlay.component'
+import { PlaytimeChipComponent } from './playtime-chip/playtime-chip.component'
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   styleUrls: ['app.component.scss'],
-  imports: [IonApp, IonRouterOutlet, PlaytimeBlockedOverlayComponent],
+  imports: [IonApp, IonRouterOutlet, PlaytimeBlockedOverlayComponent, PlaytimeChipComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {

--- a/src/frontend-box/src/app/current-media.service.ts
+++ b/src/frontend-box/src/app/current-media.service.ts
@@ -1,17 +1,52 @@
 import { Injectable } from '@angular/core'
-import { BehaviorSubject } from 'rxjs'
+import { BehaviorSubject, interval } from 'rxjs'
+import type { CurrentMPlayer } from './current.mplayer'
+import type { CurrentSpotify } from './current.spotify'
 import type { Media } from './media'
+import { MediaService } from './media.service'
 
 // Tracks the Media that the player most recently started playing. Set by
 // PlayerService.playMedia / resumeMedia. Read by the global resume-on-cap
 // effect in AppComponent so we can write a resume entry when playtime / quiet
 // hours stops playback while the user is on the home screen (and the player
 // page — which historically owned saveResumeFiles — is unmounted).
+//
+// Also gates whether a resume entry should be persisted at all: a kid touching
+// the wrong cover for a few seconds shouldn't pollute the resume swiper.
+// shouldPersistResume() returns true once the kid has actively listened to
+// the current Media for RESUME_THRESHOLD_S seconds — wall-clock pauses don't
+// count, and the counter resets on every new playMedia/resumeMedia.
 @Injectable({ providedIn: 'root' })
 export class CurrentMediaService {
+  // Active-listening seconds required before a resume entry is worth keeping.
+  // 30s is the historical value from the player.page's onLeave guard; lifting
+  // it into one service so the same intent applies to the Cap-time saver in
+  // AppComponent and to any future save path.
+  private static readonly RESUME_THRESHOLD_S = 30
+
   readonly currentMedia$ = new BehaviorSubject<Media | null>(null)
 
+  private activeSeconds = 0
+  private worthResume = false
+  private latestSpotify: CurrentSpotify | null = null
+  private latestLocal: CurrentMPlayer | null = null
+
+  constructor(mediaService: MediaService) {
+    // current$ / local$ are shareReplay'd inside MediaService — keeping a
+    // forever-subscription here is cheap and runs alongside the existing
+    // pollers (1s for mplayer, 1s/10s for Spotify depending on SDK use).
+    mediaService.current$.subscribe((s) => {
+      this.latestSpotify = s
+    })
+    mediaService.local$.subscribe((l) => {
+      this.latestLocal = l
+    })
+    interval(1000).subscribe(() => this.tick())
+  }
+
   set(media: Media | null): void {
+    this.activeSeconds = 0
+    this.worthResume = false
     this.currentMedia$.next(media ? { ...media } : null)
   }
 
@@ -20,6 +55,30 @@ export class CurrentMediaService {
   }
 
   clear(): void {
-    this.currentMedia$.next(null)
+    this.set(null)
+  }
+
+  // Single source of truth for "has this kid been listening long enough that
+  // we should persist a resume entry?" Used by every save path (player.page
+  // saveResumeFiles, AppComponent global cap saver) so the gating is
+  // consistent and based on actual listening, not wall-clock time.
+  shouldPersistResume(): boolean {
+    return this.worthResume
+  }
+
+  private tick(): void {
+    if (this.worthResume) return
+    if (!this.currentMedia$.value) return
+    if (!this.isActuallyPlaying()) return
+    this.activeSeconds++
+    if (this.activeSeconds >= CurrentMediaService.RESUME_THRESHOLD_S) {
+      this.worthResume = true
+    }
+  }
+
+  private isActuallyPlaying(): boolean {
+    if (this.latestLocal?.playing === true) return true
+    if (this.latestSpotify?.is_playing === true) return true
+    return false
   }
 }

--- a/src/frontend-box/src/app/current-media.service.ts
+++ b/src/frontend-box/src/app/current-media.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@angular/core'
+import { BehaviorSubject } from 'rxjs'
+import type { Media } from './media'
+
+// Tracks the Media that the player most recently started playing. Set by
+// PlayerService.playMedia / resumeMedia. Read by the global resume-on-cap
+// effect in AppComponent so we can write a resume entry when playtime / quiet
+// hours stops playback while the user is on the home screen (and the player
+// page — which historically owned saveResumeFiles — is unmounted).
+@Injectable({ providedIn: 'root' })
+export class CurrentMediaService {
+  readonly currentMedia$ = new BehaviorSubject<Media | null>(null)
+
+  set(media: Media | null): void {
+    this.currentMedia$.next(media ? { ...media } : null)
+  }
+
+  get(): Media | null {
+    return this.currentMedia$.value
+  }
+
+  clear(): void {
+    this.currentMedia$.next(null)
+  }
+}

--- a/src/frontend-box/src/app/home/home.page.html
+++ b/src/frontend-box/src/app/home/home.page.html
@@ -18,7 +18,6 @@
     </ion-segment>
     
     <ion-buttons slot="end">
-      <mupi-playtime-chip></mupi-playtime-chip>
       <ion-button class="status-icons" (click)="settingsButtonPressed()">
           @if (isOnline()) {
             <ion-icon name="cloud-outline"></ion-icon>

--- a/src/frontend-box/src/app/home/home.page.html
+++ b/src/frontend-box/src/app/home/home.page.html
@@ -18,6 +18,7 @@
     </ion-segment>
     
     <ion-buttons slot="end">
+      <mupi-playtime-chip></mupi-playtime-chip>
       <ion-button class="status-icons" (click)="settingsButtonPressed()">
           @if (isOnline()) {
             <ion-icon name="cloud-outline"></ion-icon>

--- a/src/frontend-box/src/app/home/home.page.ts
+++ b/src/frontend-box/src/app/home/home.page.ts
@@ -28,6 +28,7 @@ import { LoadingComponent } from '../loading/loading.component'
 import type { CategoryType } from '../media'
 import { MediaService } from '../media.service'
 import { MupiHatIconComponent } from '../mupihat-icon/mupihat-icon.component'
+import { PlaytimeChipComponent } from '../playtime-chip/playtime-chip.component'
 import { SwiperComponent, SwiperData } from '../swiper/swiper.component'
 import { SwiperIonicEventsHelper } from '../swiper/swiper-ionic-events-helper'
 
@@ -37,6 +38,7 @@ import { SwiperIonicEventsHelper } from '../swiper/swiper-ionic-events-helper'
   styleUrls: ['home.page.scss'],
   imports: [
     MupiHatIconComponent,
+    PlaytimeChipComponent,
     LoadingComponent,
     IonHeader,
     IonToolbar,

--- a/src/frontend-box/src/app/home/home.page.ts
+++ b/src/frontend-box/src/app/home/home.page.ts
@@ -28,7 +28,6 @@ import { LoadingComponent } from '../loading/loading.component'
 import type { CategoryType } from '../media'
 import { MediaService } from '../media.service'
 import { MupiHatIconComponent } from '../mupihat-icon/mupihat-icon.component'
-import { PlaytimeChipComponent } from '../playtime-chip/playtime-chip.component'
 import { SwiperComponent, SwiperData } from '../swiper/swiper.component'
 import { SwiperIonicEventsHelper } from '../swiper/swiper-ionic-events-helper'
 
@@ -38,7 +37,6 @@ import { SwiperIonicEventsHelper } from '../swiper/swiper-ionic-events-helper'
   styleUrls: ['home.page.scss'],
   imports: [
     MupiHatIconComponent,
-    PlaytimeChipComponent,
     LoadingComponent,
     IonHeader,
     IonToolbar,

--- a/src/frontend-box/src/app/player.service.ts
+++ b/src/frontend-box/src/app/player.service.ts
@@ -4,6 +4,7 @@ import type { ServerHttpApiConfig } from '@backend-api/server.model'
 import type { Observable } from 'rxjs'
 import { publishReplay, refCount } from 'rxjs/operators'
 import { environment } from '../environments/environment'
+import { CurrentMediaService } from './current-media.service'
 import { LogService } from './log.service'
 import type { Media } from './media'
 import { SpotifyService } from './spotify.service'
@@ -42,6 +43,7 @@ export class PlayerService {
     private http: HttpClient,
     private logService: LogService,
     private spotifyService: SpotifyService,
+    private currentMediaService: CurrentMediaService,
   ) {}
 
   getConfig() {
@@ -124,6 +126,10 @@ export class PlayerService {
       }
     }
 
+    // Snapshot the Media so the global resume-on-cap effect (AppComponent)
+    // knows what was playing if playtime/quiet stops it while the user is
+    // off the player page.
+    this.currentMediaService.set(media)
     this.sendRequest(url)
     return true
   }
@@ -148,6 +154,7 @@ export class PlayerService {
       url = `spotify/now/spotify:show:${encodeURIComponent(media.audiobookid)}:${media.resumespotifytrack_number}:${media.resumespotifyprogress_ms}`
     }
 
+    this.currentMediaService.set(media)
     this.sendRequest(url)
     return true
   }

--- a/src/frontend-box/src/app/player/player.page.ts
+++ b/src/frontend-box/src/app/player/player.page.ts
@@ -40,6 +40,8 @@ import type { Media } from '../media'
 import { MediaService } from '../media.service'
 import { MupiHatIconComponent } from '../mupihat-icon/mupihat-icon.component'
 import { PlayerCmds, PlayerService } from '../player.service'
+import type { PlaytimePlayState } from '../playtime.model'
+import { PlaytimeService } from '../playtime.service'
 import { SpotifyService } from '../spotify.service'
 
 @Component({
@@ -86,6 +88,9 @@ export class PlayerPage implements OnInit {
   progress = 0
   shufflechanged = 0
   tmpProgressTime = 0
+  // Tracks the playtime state across ticks so we can detect transitions
+  // (normal -> grace, grace -> blocked, etc.) and persist resume on time.
+  private prevPlaytimeState: PlaytimePlayState | 'unknown' = 'unknown'
   public readonly spotify$: Observable<CurrentSpotify>
   public readonly local$: Observable<CurrentMPlayer>
 
@@ -97,6 +102,7 @@ export class PlayerPage implements OnInit {
     private navController: NavController,
     private playerService: PlayerService,
     private spotifyService: SpotifyService,
+    private playtimeService: PlaytimeService,
   ) {
     this.spotify$ = this.mediaService.current$
     this.local$ = this.mediaService.local$
@@ -204,6 +210,7 @@ export class PlayerPage implements OnInit {
         this.saveResumeFiles()
       }
     }
+    this.checkPlaytimeForResume()
 
     if (this.media.type === 'spotify') {
       const seek = this.currentPlayedSpotify?.progress_ms || 0
@@ -348,6 +355,28 @@ export class PlayerPage implements OnInit {
         this.playerService.seekPosition(this.media.resumerssprogressTime)
       }, 2000)
     }
+  }
+
+  // The 30s saveResumeFiles cadence in updateProgress() is fine for normal use, but it
+  // can be up to 30 seconds stale when the playtime limit cuts playback off. Save
+  // immediately on the entry transition to grace and to blocked so the resume entry
+  // captures (close to) the actual stop position. In the last minute before the limit
+  // is reached, also save more frequently so the grace-entry save isn't itself stale.
+  private checkPlaytimeForResume() {
+    const status = this.playtimeService.status()
+    if (!status.enabled) {
+      this.prevPlaytimeState = 'unknown'
+      return
+    }
+    const cur = status.state
+    if (this.prevPlaytimeState !== 'unknown' && cur !== this.prevPlaytimeState) {
+      if (cur === 'grace' || cur === 'blocked') {
+        this.saveResumeFiles()
+      }
+    } else if (cur === 'normal' && this.playing && status.remainingSeconds <= 60 && this.resumeTimer % 5 === 0) {
+      this.saveResumeFiles()
+    }
+    this.prevPlaytimeState = cur
   }
 
   saveResumeFiles() {

--- a/src/frontend-box/src/app/player/player.page.ts
+++ b/src/frontend-box/src/app/player/player.page.ts
@@ -362,10 +362,11 @@ export class PlayerPage implements OnInit {
   }
 
   // The 30s saveResumeFiles cadence in updateProgress() is fine for normal use, but it
-  // can be up to 30 seconds stale when the playtime limit cuts playback off. Save
-  // immediately on the entry transition to grace and to blocked so the resume entry
-  // captures (close to) the actual stop position. In the last minute before the limit
-  // is reached, also save more frequently so the grace-entry save isn't itself stale.
+  // can be up to 30 seconds stale when playback is cut off (playtime cap or quiet
+  // hours window). Save immediately on the entry transition to grace and to blocked
+  // so the resume entry captures (close to) the actual stop position. In the last
+  // minute before the playtime limit, also save more frequently so the grace-entry
+  // save isn't itself stale.
   private checkPlaytimeForResume() {
     const status = this.playtimeService.status()
     if (!status.enabled) {
@@ -377,7 +378,13 @@ export class PlayerPage implements OnInit {
       if (cur === 'grace' || cur === 'blocked') {
         this.saveResumeFiles()
       }
-    } else if (cur === 'normal' && this.playing && status.remainingSeconds <= 60 && this.resumeTimer % 5 === 0) {
+    } else if (
+      cur === 'normal' &&
+      this.playing &&
+      status.playtime.enabled &&
+      status.playtime.remainingSeconds <= 60 &&
+      this.resumeTimer % 5 === 0
+    ) {
       this.saveResumeFiles()
     }
     this.prevPlaytimeState = cur

--- a/src/frontend-box/src/app/player/player.page.ts
+++ b/src/frontend-box/src/app/player/player.page.ts
@@ -1,5 +1,6 @@
 import { AsyncPipe } from '@angular/common'
-import { Component, OnInit, ViewChild } from '@angular/core'
+import { Component, DestroyRef, inject, OnInit, ViewChild } from '@angular/core'
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
 import { FormsModule } from '@angular/forms'
 import { ActivatedRoute, Router } from '@angular/router'
 import {
@@ -91,6 +92,7 @@ export class PlayerPage implements OnInit {
   // Tracks the playtime state across ticks so we can detect transitions
   // (normal -> grace, grace -> blocked, etc.) and persist resume on time.
   private prevPlaytimeState: PlaytimePlayState | 'unknown' = 'unknown'
+  private destroyRef = inject(DestroyRef)
   public readonly spotify$: Observable<CurrentSpotify>
   public readonly local$: Observable<CurrentMPlayer>
 
@@ -136,14 +138,12 @@ export class PlayerPage implements OnInit {
       this.handleExternalPlayback()
     }
 
-    this.mediaService.current$.subscribe((spotify) => {
+    // Track player state for the lifetime of this component. takeUntilDestroyed
+    // ties the subscription to the page; previously updateProgress() and
+    // saveResumeFiles() each re-subscribed on every call without ever
+    // unsubscribing, so a 60-min listen accrued ~120 lingering subscriptions.
+    this.mediaService.current$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((spotify) => {
       this.currentPlayedSpotify = spotify
-    })
-    this.mediaService.local$.subscribe((local) => {
-      this.currentPlayedLocal = local
-    })
-    // Use cover from CurrentSpotify for Spotify content, fallback to media.cover for other types
-    this.mediaService.current$.subscribe((spotify) => {
       if (this.media?.type === 'spotify' && spotify?.item?.album?.images?.[0]?.url) {
         this.cover = spotify.item.album.images[0].url
       } else if (this.media?.cover) {
@@ -152,7 +152,10 @@ export class PlayerPage implements OnInit {
         this.cover = '../assets/images/nocover_mupi.png'
       }
     })
-    this.mediaService.albumStop$.subscribe((albumStop) => {
+    this.mediaService.local$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((local) => {
+      this.currentPlayedLocal = local
+    })
+    this.mediaService.albumStop$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((albumStop) => {
       this.albumStop = albumStop
     })
   }
@@ -176,7 +179,7 @@ export class PlayerPage implements OnInit {
       }
 
       // Subscribe to currentTrack$ to update when track info becomes available
-      this.spotifyService.currentTrack$.subscribe((track) => {
+      this.spotifyService.currentTrack$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((track) => {
         if (track && this.media.title === 'External Playback') {
           this.logService.log('[PlayerPage] Updating media object with track info:', track.name)
           this.media = this.spotifyService.createMediaFromSpotifyTrack(track)
@@ -196,13 +199,9 @@ export class PlayerPage implements OnInit {
   }
 
   updateProgress() {
-    this.mediaService.current$.subscribe((spotify) => {
-      this.currentPlayedSpotify = spotify
-    })
-    this.mediaService.local$.subscribe((local) => {
-      this.currentPlayedLocal = local
-    })
-
+    // currentPlayedSpotify / currentPlayedLocal are kept fresh by the
+    // takeUntilDestroyed-bound subscriptions in ngOnInit — read them
+    // directly here instead of re-subscribing on every tick.
     this.playing = !this.currentPlayedLocal?.pause
     if (this.playing) {
       this.resumeTimer++
@@ -381,12 +380,6 @@ export class PlayerPage implements OnInit {
 
   saveResumeFiles() {
     this.resumemedia = Object.assign({}, this.media)
-    this.mediaService.current$.subscribe((spotify) => {
-      this.currentPlayedSpotify = spotify
-    })
-    this.mediaService.local$.subscribe((local) => {
-      this.currentPlayedLocal = local
-    })
     if (this.resumemedia.type === 'spotify' && this.resumemedia?.showid) {
       this.resumemedia.resumespotifytrack_number = this.currentPlayedSpotify?.item?.track_number || 1
       this.resumemedia.resumespotifyprogress_ms = this.currentPlayedSpotify?.progress_ms || 0

--- a/src/frontend-box/src/app/player/player.page.ts
+++ b/src/frontend-box/src/app/player/player.page.ts
@@ -34,6 +34,7 @@ import {
 } from 'ionicons/icons'
 import type { Observable } from 'rxjs'
 import type { AlbumStop } from '../albumstop'
+import { CurrentMediaService } from '../current-media.service'
 import type { CurrentMPlayer } from '../current.mplayer'
 import type { CurrentSpotify } from '../current.spotify'
 import { LogService } from '../log.service'
@@ -105,6 +106,7 @@ export class PlayerPage implements OnInit {
     private playerService: PlayerService,
     private spotifyService: SpotifyService,
     private playtimeService: PlaytimeService,
+    private currentMediaService: CurrentMediaService,
   ) {
     this.spotify$ = this.mediaService.current$
     this.local$ = this.mediaService.local$
@@ -288,9 +290,12 @@ export class PlayerPage implements OnInit {
     if (
       (this.media.type === 'spotify' || this.media.type === 'library' || this.media.type === 'rss') &&
       !this.media.shuffle &&
-      this.resumeTimer > 30 &&
       this.playing
     ) {
+      // saveResumeFiles itself enforces the listening-time threshold via
+      // CurrentMediaService.shouldPersistResume(); the local resumeTimer > 30
+      // guard that used to live here is gone — it was page-mount-scoped and
+      // wall-clock-based, both of which the central service handles better.
       this.saveResumeFiles()
     }
     this.updateProgression = false
@@ -379,6 +384,11 @@ export class PlayerPage implements OnInit {
   }
 
   saveResumeFiles() {
+    // Single gate for "is this listen worth persisting?" — covers the 30s
+    // updateProgress cadence, the on-leave save, and the cap-transition save.
+    // Resets on every new playMedia/resumeMedia, counts only active playback.
+    if (!this.currentMediaService.shouldPersistResume()) return
+
     this.resumemedia = Object.assign({}, this.media)
     if (this.resumemedia.type === 'spotify' && this.resumemedia?.showid) {
       this.resumemedia.resumespotifytrack_number = this.currentPlayedSpotify?.item?.track_number || 1

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
@@ -2,6 +2,10 @@
   <div class="content">
     <ion-icon name="moon-outline" class="icon" aria-hidden="true"></ion-icon>
     <h1>Heute war genug Musik</h1>
-    <p>Morgen geht's weiter 🎶</p>
+    <p>
+      <ion-icon name="musical-notes-outline" class="inline-icon" aria-hidden="true"></ion-icon>
+      Morgen geht's weiter
+      <ion-icon name="musical-notes-outline" class="inline-icon" aria-hidden="true"></ion-icon>
+    </p>
   </div>
 </div>

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
@@ -1,0 +1,7 @@
+<div class="playtime-blocked-overlay" (click)="$event.stopPropagation()">
+  <div class="content">
+    <ion-icon name="moon-outline" class="icon" aria-hidden="true"></ion-icon>
+    <h1>Heute war genug Musik</h1>
+    <p>Morgen geht's weiter 🎶</p>
+  </div>
+</div>

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.html
@@ -1,10 +1,10 @@
 <div class="playtime-blocked-overlay" (click)="$event.stopPropagation()">
   <div class="content">
-    <ion-icon name="moon-outline" class="icon" aria-hidden="true"></ion-icon>
-    <h1>Heute war genug Musik</h1>
+    <ion-icon [name]="content().iconName" class="icon" aria-hidden="true"></ion-icon>
+    <h1>{{ content().heading }}</h1>
     <p>
       <ion-icon name="musical-notes-outline" class="inline-icon" aria-hidden="true"></ion-icon>
-      Morgen geht's weiter
+      {{ content().subheading }}
       <ion-icon name="musical-notes-outline" class="inline-icon" aria-hidden="true"></ion-icon>
     </p>
   </div>

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.scss
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.scss
@@ -37,5 +37,14 @@
     opacity: 0.8;
     margin: 0;
     line-height: 1.3;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .inline-icon {
+    font-size: 1.4rem;
+    opacity: 0.85;
+    vertical-align: middle;
   }
 }

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.scss
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.scss
@@ -1,0 +1,41 @@
+.playtime-blocked-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
+  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  user-select: none;
+  cursor: default;
+
+  .content {
+    color: #ffffff;
+    padding: 2rem;
+    max-width: 90%;
+  }
+
+  .icon {
+    font-size: 96px;
+    margin-bottom: 1.5rem;
+    opacity: 0.85;
+  }
+
+  h1 {
+    font-size: 2rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem 0;
+    line-height: 1.2;
+  }
+
+  p {
+    font-size: 1.25rem;
+    opacity: 0.8;
+    margin: 0;
+    line-height: 1.3;
+  }
+}

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
@@ -1,7 +1,15 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core'
 import { IonIcon } from '@ionic/angular/standalone'
 import { addIcons } from 'ionicons'
-import { moonOutline, musicalNotesOutline } from 'ionicons/icons'
+import { hourglassOutline, moonOutline, musicalNotesOutline } from 'ionicons/icons'
+import type { PlaybackBlockSource } from '../playtime.model'
+import { PlaytimeService } from '../playtime.service'
+
+interface OverlayContent {
+  iconName: string
+  heading: string
+  subheading: string
+}
 
 @Component({
   selector: 'mupi-playtime-blocked',
@@ -11,7 +19,39 @@ import { moonOutline, musicalNotesOutline } from 'ionicons/icons'
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PlaytimeBlockedOverlayComponent {
+  private playtimeService = inject(PlaytimeService)
+
+  protected readonly content: Signal<OverlayContent> = computed(() => {
+    const s = this.playtimeService.status()
+    if (s.enabled !== true) return DEFAULT_PLAYTIME_CONTENT
+    return contentForBlock(s.blockSource, s.quiet.label)
+  })
+
   constructor() {
-    addIcons({ moonOutline, musicalNotesOutline })
+    addIcons({ moonOutline, musicalNotesOutline, hourglassOutline })
   }
+}
+
+const DEFAULT_PLAYTIME_CONTENT: OverlayContent = {
+  iconName: 'moon-outline',
+  heading: 'Heute war genug Musik',
+  subheading: "Morgen geht's weiter",
+}
+
+function contentForBlock(source: PlaybackBlockSource | null, quietLabel: string | undefined): OverlayContent {
+  if (source === 'quiet') {
+    if (quietLabel?.trim()) {
+      return {
+        iconName: 'hourglass-outline',
+        heading: quietLabel,
+        subheading: 'Bald gibt es wieder Musik',
+      }
+    }
+    return {
+      iconName: 'moon-outline',
+      heading: 'Ruhezeit',
+      subheading: 'Bald gibt es wieder Musik',
+    }
+  }
+  return DEFAULT_PLAYTIME_CONTENT
 }

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
@@ -1,0 +1,17 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core'
+import { IonIcon } from '@ionic/angular/standalone'
+import { addIcons } from 'ionicons'
+import { moonOutline } from 'ionicons/icons'
+
+@Component({
+  selector: 'mupi-playtime-blocked',
+  templateUrl: './playtime-blocked-overlay.component.html',
+  styleUrls: ['./playtime-blocked-overlay.component.scss'],
+  imports: [IonIcon],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PlaytimeBlockedOverlayComponent {
+  constructor() {
+    addIcons({ moonOutline })
+  }
+}

--- a/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
+++ b/src/frontend-box/src/app/playtime-blocked-overlay/playtime-blocked-overlay.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core'
 import { IonIcon } from '@ionic/angular/standalone'
 import { addIcons } from 'ionicons'
-import { moonOutline } from 'ionicons/icons'
+import { moonOutline, musicalNotesOutline } from 'ionicons/icons'
 
 @Component({
   selector: 'mupi-playtime-blocked',
@@ -12,6 +12,6 @@ import { moonOutline } from 'ionicons/icons'
 })
 export class PlaytimeBlockedOverlayComponent {
   constructor() {
-    addIcons({ moonOutline })
+    addIcons({ moonOutline, musicalNotesOutline })
   }
 }

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.html
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.html
@@ -1,0 +1,6 @@
+@if (visible()) {
+  <div class="playtime-chip" [attr.data-level]="level()" aria-label="Verbleibende Hörzeit">
+    <ion-icon name="time-outline" aria-hidden="true"></ion-icon>
+    <span>{{ remainingMinutes() }} min</span>
+  </div>
+}

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
@@ -1,0 +1,29 @@
+.playtime-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  margin-right: 8px;
+  border-radius: 14px;
+  font-size: 14px;
+  font-weight: 500;
+  background: rgba(255, 255, 255, 0.15);
+  color: rgba(255, 255, 255, 0.9);
+  user-select: none;
+  pointer-events: none;
+  white-space: nowrap;
+
+  ion-icon {
+    font-size: 16px;
+  }
+
+  &[data-level='warning'] {
+    background: rgba(255, 193, 7, 0.85);
+    color: #1a1a1a;
+  }
+
+  &[data-level='critical'] {
+    background: rgba(244, 67, 54, 0.9);
+    color: #ffffff;
+  }
+}

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
@@ -1,29 +1,35 @@
 .playtime-chip {
+  position: fixed;
+  top: 6px;
+  right: 8px;
+  z-index: 9000;
   display: inline-flex;
   align-items: center;
   gap: 6px;
   padding: 4px 10px;
-  margin-right: 8px;
   border-radius: 14px;
   font-size: 14px;
   font-weight: 500;
-  background: rgba(255, 255, 255, 0.15);
-  color: rgba(255, 255, 255, 0.9);
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
   user-select: none;
   pointer-events: none;
   white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
 
   ion-icon {
     font-size: 16px;
   }
 
   &[data-level='warning'] {
-    background: rgba(255, 193, 7, 0.85);
+    background: rgba(255, 193, 7, 0.9);
     color: #1a1a1a;
   }
 
   &[data-level='critical'] {
-    background: rgba(244, 67, 54, 0.9);
+    background: rgba(244, 67, 54, 0.92);
     color: #ffffff;
   }
 }

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.scss
@@ -1,6 +1,9 @@
 .playtime-chip {
   position: fixed;
-  top: 6px;
+  // Sit just below the typical ion-toolbar (56px in md mode) so the chip
+  // never overlaps the cloud/battery icons (home), the volume + track
+  // counter (player), or any other toolbar elements on other pages.
+  top: 64px;
   right: 8px;
   z-index: 9000;
   display: inline-flex;

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, computed, inject, Signal } from '@angular/core'
+import { IonIcon } from '@ionic/angular/standalone'
+import { addIcons } from 'ionicons'
+import { timeOutline } from 'ionicons/icons'
+import { PlaytimeService } from '../playtime.service'
+
+type ChipLevel = 'normal' | 'warning' | 'critical'
+
+@Component({
+  selector: 'mupi-playtime-chip',
+  templateUrl: './playtime-chip.component.html',
+  styleUrls: ['./playtime-chip.component.scss'],
+  imports: [IonIcon],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PlaytimeChipComponent {
+  private playtimeService = inject(PlaytimeService)
+
+  protected readonly visible: Signal<boolean> = computed(() => {
+    const s = this.playtimeService.status()
+    return s.enabled === true && !s.blocked
+  })
+
+  protected readonly remainingMinutes: Signal<number> = computed(() => {
+    const s = this.playtimeService.status()
+    if (s.enabled !== true) return 0
+    return Math.ceil(s.remainingSeconds / 60)
+  })
+
+  protected readonly level: Signal<ChipLevel> = computed(() => {
+    const m = this.remainingMinutes()
+    if (m < 10) return 'critical'
+    if (m < 30) return 'warning'
+    return 'normal'
+  })
+
+  constructor() {
+    addIcons({ timeOutline })
+  }
+}

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
@@ -18,13 +18,15 @@ export class PlaytimeChipComponent {
 
   protected readonly visible: Signal<boolean> = computed(() => {
     const s = this.playtimeService.status()
-    return s.enabled === true && s.state === 'normal'
+    // Show only when playtime is enabled AND nothing is restricting playback
+    // (combined state is 'normal'). Quiet-only setups have no countdown to show.
+    return s.enabled === true && s.playtime.enabled && s.state === 'normal'
   })
 
   protected readonly remainingMinutes: Signal<number> = computed(() => {
     const s = this.playtimeService.status()
-    if (s.enabled !== true) return 0
-    return Math.ceil(s.remainingSeconds / 60)
+    if (s.enabled !== true || !s.playtime.enabled) return 0
+    return Math.ceil(s.playtime.remainingSeconds / 60)
   })
 
   protected readonly level: Signal<ChipLevel> = computed(() => {

--- a/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
+++ b/src/frontend-box/src/app/playtime-chip/playtime-chip.component.ts
@@ -18,7 +18,7 @@ export class PlaytimeChipComponent {
 
   protected readonly visible: Signal<boolean> = computed(() => {
     const s = this.playtimeService.status()
-    return s.enabled === true && !s.blocked
+    return s.enabled === true && s.state === 'normal'
   })
 
   protected readonly remainingMinutes: Signal<number> = computed(() => {

--- a/src/frontend-box/src/app/playtime.model.ts
+++ b/src/frontend-box/src/app/playtime.model.ts
@@ -2,14 +2,16 @@ export type PlaytimeDayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'su
 
 export type PlaytimePlayState = 'normal' | 'grace' | 'blocked'
 
-export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
+export type PlaybackBlockSource = 'playtime' | 'quiet'
+
+export type PlaytimeStatus = PlaytimeStatusActive | PlaytimeStatusDisabled
 
 export interface PlaytimeStatusDisabled {
   enabled: false
 }
 
-export interface PlaytimeStatusEnabled {
-  enabled: true
+export interface PlaytimeSubStatus {
+  enabled: boolean
   state: PlaytimePlayState
   date: string
   dayKey: PlaytimeDayKey
@@ -18,4 +20,20 @@ export interface PlaytimeStatusEnabled {
   remainingSeconds: number
   graceEndsInSeconds: number
   resetHour: number
+}
+
+export interface QuietHoursSubStatus {
+  enabled: boolean
+  state: PlaytimePlayState
+  inWindow: boolean
+  label?: string
+  graceEndsInSeconds: number
+}
+
+export interface PlaytimeStatusActive {
+  enabled: true
+  state: PlaytimePlayState
+  blockSource: PlaybackBlockSource | null
+  playtime: PlaytimeSubStatus
+  quiet: QuietHoursSubStatus
 }

--- a/src/frontend-box/src/app/playtime.model.ts
+++ b/src/frontend-box/src/app/playtime.model.ts
@@ -1,0 +1,18 @@
+export type PlaytimeDayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
+
+export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
+
+export interface PlaytimeStatusDisabled {
+  enabled: false
+}
+
+export interface PlaytimeStatusEnabled {
+  enabled: true
+  date: string
+  dayKey: PlaytimeDayKey
+  limitMinutes: number
+  usedSeconds: number
+  remainingSeconds: number
+  blocked: boolean
+  resetHour: number
+}

--- a/src/frontend-box/src/app/playtime.model.ts
+++ b/src/frontend-box/src/app/playtime.model.ts
@@ -1,5 +1,7 @@
 export type PlaytimeDayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun'
 
+export type PlaytimePlayState = 'normal' | 'grace' | 'blocked'
+
 export type PlaytimeStatus = PlaytimeStatusEnabled | PlaytimeStatusDisabled
 
 export interface PlaytimeStatusDisabled {
@@ -8,11 +10,12 @@ export interface PlaytimeStatusDisabled {
 
 export interface PlaytimeStatusEnabled {
   enabled: true
+  state: PlaytimePlayState
   date: string
   dayKey: PlaytimeDayKey
   limitMinutes: number
   usedSeconds: number
   remainingSeconds: number
-  blocked: boolean
+  graceEndsInSeconds: number
   resetHour: number
 }

--- a/src/frontend-box/src/app/playtime.service.ts
+++ b/src/frontend-box/src/app/playtime.service.ts
@@ -5,7 +5,9 @@ import { catchError, of, switchMap, timer } from 'rxjs'
 import { environment } from 'src/environments/environment'
 import type { PlaytimeStatus } from './playtime.model'
 
-const POLL_INTERVAL_MS = 30_000
+// Polled by chip + overlay + player page. Endpoint just reads /tmp/playtime.json
+// (tmpfs), so 5s is fine and gives snappy state transitions in the UI.
+const POLL_INTERVAL_MS = 5_000
 
 @Injectable({ providedIn: 'root' })
 export class PlaytimeService {

--- a/src/frontend-box/src/app/playtime.service.ts
+++ b/src/frontend-box/src/app/playtime.service.ts
@@ -1,0 +1,24 @@
+import { HttpClient } from '@angular/common/http'
+import { Injectable, inject, Signal } from '@angular/core'
+import { toSignal } from '@angular/core/rxjs-interop'
+import { catchError, of, switchMap, timer } from 'rxjs'
+import { environment } from 'src/environments/environment'
+import type { PlaytimeStatus } from './playtime.model'
+
+const POLL_INTERVAL_MS = 30_000
+
+@Injectable({ providedIn: 'root' })
+export class PlaytimeService {
+  private http = inject(HttpClient)
+
+  readonly status: Signal<PlaytimeStatus> = toSignal(
+    timer(0, POLL_INTERVAL_MS).pipe(
+      switchMap(() =>
+        this.http
+          .get<PlaytimeStatus>(`${environment.backend.apiUrl}/playtime`)
+          .pipe(catchError(() => of<PlaytimeStatus>({ enabled: false }))),
+      ),
+    ),
+    { initialValue: { enabled: false } as PlaytimeStatus },
+  )
+}

--- a/src/frontend-box/src/app/resume-builder.ts
+++ b/src/frontend-box/src/app/resume-builder.ts
@@ -1,0 +1,36 @@
+import type { CurrentMPlayer } from './current.mplayer'
+import type { CurrentSpotify } from './current.spotify'
+import type { Media } from './media'
+
+// Builds a resume-shaped Media from the Media that started playback plus the
+// most recent player state. Mirrors the field-mapping that lived inline in
+// player.page.ts:saveResumeFiles so both the in-page saver and the global
+// resume-on-cap effect produce identical entries (which lets the backend's
+// composite-key dedup overwrite cleanly instead of duplicating).
+export function buildResumeMedia(
+  source: Media,
+  spotify: CurrentSpotify | null | undefined,
+  local: CurrentMPlayer | null | undefined,
+): Media {
+  const resume: Media = { ...source }
+
+  if (resume.type === 'spotify' && resume.showid) {
+    resume.resumespotifytrack_number = spotify?.item?.track_number || 1
+    resume.resumespotifyprogress_ms = spotify?.progress_ms || 0
+    resume.resumespotifyduration_ms = spotify?.item?.duration_ms || 0
+  } else if (resume.type === 'spotify') {
+    resume.resumespotifytrack_number = spotify?.item?.track_number || 0
+    resume.resumespotifyprogress_ms = spotify?.progress_ms || 0
+    resume.resumespotifyduration_ms = spotify?.item?.duration_ms || 0
+  } else if (resume.type === 'library') {
+    resume.resumelocalalbum = resume.category
+    resume.resumelocalcurrentTracknr = local?.currentTracknr || 0
+    resume.resumelocalprogressTime = local?.progressTime || 0
+  } else if (resume.type === 'rss') {
+    resume.resumerssprogressTime = local?.progressTime || 0
+  }
+
+  resume.category = 'resume'
+  resume.index = undefined
+  return resume
+}


### PR DESCRIPTION
## Was es macht
- Per-Weekday Zeitfenster mit benannten Slots („Hausaufgaben", „Schlafenszeit" — frei benennbar)
- Multi-Window pro Tag möglich (z.B. 14:00-16:00 + 20:00-08:00)
- Im aktiven Window: Player stoppt, Blocked-Overlay mit Slot-Name, kein Start möglich
- Admin-UI-Description für jeden Slot mit Begründung (was das Kind zu sehen bekommt)
- Override-Guard für `/release allowUntil` aus Telegram-Bot (siehe Telegram-PR) — Override gilt bis zur angegebenen Zeit, nicht permanent

## Architektur (kurz)
Läuft parallel zur Playtime-Limit-Logik aus dem Playtime-PR — beide nutzen denselben `mupi.php`-Status-Endpoint, Frontend wertet die strengere der beiden Quellen aus (Quiet ODER Playtime). Zeitfenster-Auswertung passiert im selben Tick wie der Playtime-Counter.

## Test in Codespaces / lokal
1. Branch auschecken (basiert auf Playtime-PR)
2. Setup wie beim Playtime-PR
3. Konkrete Tests:
   - Admin-UI „Quiet Hours" Sektion: Slot „Schlafenszeit" 22:00-07:00 für alle Tage anlegen
   - Systemzeit auf 22:30 mocken (oder real abwarten) → Player gestoppt, Overlay „Schlafenszeit"
   - Track starten versuchen → blockiert
   - Override via `/release allowUntil 23:00` → freigegeben, danach wieder blockiert

**Hinweis:** Telegram-Override-Test braucht den Telegram-PR.

## Abhängigkeit
Stacked auf #151 (Playtime-Limit) — bitte erst #151 mergen.
